### PR TITLE
Feature/186 use registration service

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -14,9 +14,9 @@ runs:
     - name: Checkout Registration Service
       uses: actions/checkout@v2
       with:
-        repository: agera-edc/RegistrationService
+        repository: agera-edc/RegistrationServiceFork
         path: RegistrationService
-        ref: f47e3ce3c40daa6713778f9a13e1129d053ecbb5
+        ref: 83b6cd1013d2330253477d2713a660f1babdab16
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2
@@ -58,6 +58,6 @@ runs:
       shell: bash
       working-directory: RegistrationService
 
-    - name: Delete Registration Service packages
-      run: rm -r RegistrationService
+    - name: Move Registration Service packages out of build directory
+      run: mv RegistrationService ${{ runner.temp }}
       shell: bash

--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -14,9 +14,9 @@ runs:
     - name: Checkout Registration Service
       uses: actions/checkout@v2
       with:
-        repository: agera-edc/RegistrationServiceFork
+        repository: agera-edc/RegistrationService
         path: RegistrationService
-        ref: 83b6cd1013d2330253477d2713a660f1babdab16
+        ref: 526717e1a2db085b90f411e1357447b7e5c9543b
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2
@@ -58,6 +58,7 @@ runs:
       shell: bash
       working-directory: RegistrationService
 
+    # Keep RegistrationService sources as needed for build
     - name: Move Registration Service packages out of build directory
       run: mv RegistrationService ${{ runner.temp }}
       shell: bash

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,12 +74,8 @@ jobs:
     env:
       ACR_NAME: ${{ secrets.ACR_NAME }}
     steps:
-      # Checkout Registration service code
-      - name: Checkout Registration Service
-        uses: actions/checkout@v2
-        with:
-          repository: agera-edc/RegistrationService
-          ref: f47e3ce3c40daa6713778f9a13e1129d053ecbb5
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/gradle-setup
 
       - name: 'Az CLI login'
         uses: azure/login@v1
@@ -91,17 +87,16 @@ jobs:
       - name: 'Login to ACR'
         run: az acr login -n $ACR_NAME
 
-      - uses: ./.github/actions/gradle-setup
-
       # Build Registration Service runtime JAR locally.
       # The result is a JAR file in launcher/build/libs.
       - name: 'Build runtime JAR'
         run: ./gradlew launcher:shadowJar
+        working-directory: ${{ runner.temp }}/RegistrationService
 
       # Build Docker runtime image remotely on ACR & push it to the registry.
       - name: 'Build image'
         run: az acr build --registry $ACR_NAME --image mvd/registration-service:${{ env.RESOURCES_PREFIX }} .
-        working-directory: launcher
+        working-directory: ${{ runner.temp }}/RegistrationService/launcher
 
   # Build data dashboard webapp
   Build-Dashboard:
@@ -160,8 +155,6 @@ jobs:
           resource_group = "rg-${{ env.RESOURCES_PREFIX }}"
           registry_runtime_image = "mvd/registration-service:${{ env.RESOURCES_PREFIX }}"
           registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
-          registry_storage_account = "${{ secrets.REGISTRY_STORAGE_ACCOUNT }}"
-          registry_share = "${{ secrets.REGISTRY_SHARE }}"
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           EOF
 
@@ -270,8 +263,6 @@ jobs:
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           application_sp_client_id = "${{ secrets.APP_CLIENT_ID }}"
           registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
-          registry_storage_account = "${{ secrets.REGISTRY_STORAGE_ACCOUNT }}"
-          registry_share = "${{ secrets.REGISTRY_SHARE }}"
           registration_service_api_url = "${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/api"
           EOF
 
@@ -342,6 +333,14 @@ jobs:
           npm install -g newman
           deployment/seed-data.sh
         working-directory: .
+
+      - name: 'Register participant'
+        run: |
+          curl -vfd '{ "name": "${{matrix.participant}}", "supportedProtocols": [ "ids-multipart" ], "url": "http://${{ env.EDC_HOST }}:8282" }' \
+            -HContent-type:application/json \
+            $REGISTRATION_SERVICE_API_URL/registry/participant
+        env:
+          REGISTRATION_SERVICE_API_URL: ${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/api
 
   Verify:
     needs:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -154,7 +154,6 @@ jobs:
           prefix = "${{ env.RESOURCES_PREFIX }}"
           resource_group = "rg-${{ env.RESOURCES_PREFIX }}"
           registry_runtime_image = "mvd/registration-service:${{ env.RESOURCES_PREFIX }}"
-          registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           EOF
 
@@ -262,7 +261,6 @@ jobs:
           dashboard_image = "mvd/data-dashboard:${{ env.RESOURCES_PREFIX }}"
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           application_sp_client_id = "${{ secrets.APP_CLIENT_ID }}"
-          registry_resource_group = "${{ secrets.COMMON_RESOURCE_GROUP }}"
           registration_service_api_url = "${{ needs.Deploy-Dataspace.outputs.registration_service_url }}/api"
           EOF
 

--- a/.github/workflows/initialize.yaml
+++ b/.github/workflows/initialize.yaml
@@ -18,8 +18,6 @@ jobs:
       COMMON_RESOURCE_GROUP_LOCATION: ${{ secrets.COMMON_RESOURCE_GROUP_LOCATION }}
       TERRAFORM_STATE_STORAGE_ACCOUNT: ${{ secrets.TERRAFORM_STATE_STORAGE_ACCOUNT }}
       TERRAFORM_STATE_CONTAINER: ${{ secrets.TERRAFORM_STATE_CONTAINER }}
-      REGISTRY_STORAGE_ACCOUNT: ${{ secrets.REGISTRY_STORAGE_ACCOUNT }}
-      REGISTRY_SHARE: ${{ secrets.REGISTRY_SHARE }}
       ACR_NAME: ${{ secrets.ACR_NAME }}
 
     steps:
@@ -40,8 +38,3 @@ jobs:
 
       - name: "Create Azure Container Registry"
         run: az acr create --resource-group "$COMMON_RESOURCE_GROUP" --name "$ACR_NAME" --sku Basic --admin-enabled -o table
-
-      - name: "Create Registry Storage account"
-        run: |
-          az storage account create --name ${REGISTRY_STORAGE_ACCOUNT} --resource-group ${COMMON_RESOURCE_GROUP} -o table
-          az storage share create --name ${REGISTRY_SHARE} --account-name ${REGISTRY_STORAGE_ACCOUNT} -o table

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -32,16 +32,6 @@ data "azurerm_container_registry" "registry" {
   resource_group_name = var.acr_resource_group
 }
 
-data "azurerm_storage_account" "registry" {
-  name                = var.registry_storage_account
-  resource_group_name = var.registry_resource_group
-}
-
-data "azurerm_storage_share" "registry" {
-  name                 = var.registry_share
-  storage_account_name = data.azurerm_storage_account.registry.name
-}
-
 locals {
   registry_files_prefix = "${var.prefix}-"
 
@@ -66,7 +56,7 @@ resource "azurerm_application_insights" "dataspace" {
 }
 
 resource "azurerm_container_group" "registration-service" {
-  name                = "${var.prefix}-registration-service"
+  name                = "${var.prefix}-registration-mvd"
   location            = var.location
   resource_group_name = azurerm_resource_group.dataspace.name
   ip_address_type     = "Public"
@@ -92,17 +82,6 @@ resource "azurerm_container_group" "registration-service" {
 
     environment_variables = {
       EDC_CONNECTOR_NAME = local.connector_name
-
-      NODES_JSON_DIR          = "/registry"
-      NODES_JSON_FILES_PREFIX = local.registry_files_prefix
-    }
-
-    volume {
-      storage_account_name = data.azurerm_storage_account.registry.name
-      storage_account_key  = data.azurerm_storage_account.registry.primary_access_key
-      share_name           = data.azurerm_storage_share.registry.name
-      mount_path           = "/registry"
-      name                 = "registry"
     }
 
     liveness_probe {

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -35,14 +35,6 @@ variable "registry_resource_group" {
   description = "resource group of the registration service"
 }
 
-variable "registry_storage_account" {
-  description = "name of the registration service storage account"
-}
-
-variable "registry_share" {
-  description = "name of the registry JSON documents file share"
-}
-
 variable "application_sp_object_id" {
   description = "object id of application's service principal object"
 }

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -31,10 +31,6 @@ variable "container_memory" {
   default = "8"
 }
 
-variable "registry_resource_group" {
-  description = "resource group of the registration service"
-}
-
 variable "application_sp_object_id" {
   description = "object id of application's service principal object"
 }

--- a/deployment/terraform/participant/main.tf
+++ b/deployment/terraform/participant/main.tf
@@ -36,16 +36,6 @@ data "azurerm_container_registry" "registry" {
   resource_group_name = var.acr_resource_group
 }
 
-data "azurerm_storage_account" "registry" {
-  name                = var.registry_storage_account
-  resource_group_name = var.registry_resource_group
-}
-
-data "azurerm_storage_share" "registry" {
-  name                 = var.registry_share
-  storage_account_name = data.azurerm_storage_account.registry.name
-}
-
 locals {
   registry_files_prefix = "${var.prefix}-"
 
@@ -131,14 +121,6 @@ resource "azurerm_container_group" "edc" {
       EDC_API_AUTH_KEY = local.api_key
 
       APPLICATIONINSIGHTS_CONNECTION_STRING = var.app_insights_connection_string
-    }
-
-    volume {
-      storage_account_name = data.azurerm_storage_account.registry.name
-      storage_account_key  = data.azurerm_storage_account.registry.primary_access_key
-      share_name           = data.azurerm_storage_share.registry.name
-      mount_path           = "/registry"
-      name                 = "registry"
     }
 
     liveness_probe {
@@ -343,10 +325,4 @@ resource "local_file" "registry_entry" {
     supportedProtocols = ["ids-multipart"]
   })
   filename = "${path.module}/build/${var.participant_name}.json"
-}
-
-resource "azurerm_storage_share_file" "registry_entry" {
-  name             = "${local.registry_files_prefix}${var.participant_name}.json"
-  storage_share_id = data.azurerm_storage_share.registry.id
-  source           = local_file.registry_entry.filename
 }

--- a/deployment/terraform/participant/variables.tf
+++ b/deployment/terraform/participant/variables.tf
@@ -75,14 +75,6 @@ variable "registry_resource_group" {
   description = "resource group of the registry JSON documents file share storage account"
 }
 
-variable "registry_storage_account" {
-  description = "name of the registry JSON documents file share storage account"
-}
-
-variable "registry_share" {
-  description = "name of the registry JSON documents file share"
-}
-
 variable "registration_service_api_url" {
   description = "registration api url"
 }

--- a/deployment/terraform/participant/variables.tf
+++ b/deployment/terraform/participant/variables.tf
@@ -71,10 +71,6 @@ variable "public_key_jwk_file" {
   default     = null
 }
 
-variable "registry_resource_group" {
-  description = "resource group of the registry JSON documents file share storage account"
-}
-
 variable "registration_service_api_url" {
   description = "registration api url"
 }

--- a/docs/developer/continuous_deployment.md
+++ b/docs/developer/continuous_deployment.md
@@ -8,7 +8,6 @@ A GitHub Actions workflow performs continuous integration and continuous deploym
 - Another **application** is created to represent the deployed runtimes for accessing Azure resources (such as Key Vault). For simplicity, all runtimes share a single application identity. In Azure Active Directory, a service principal for the application is configured in the cloud tenant. A client secret is configured to allow the runtime to authenticate.
 - An **Azure Container Registry** instance is deployed to contain docker images built in the CI job. These images are deployed to runtime environments in the CD process.
 - An **Azure Storage Account** and a storage container to store **Terraform state** between the deployment and destroy jobs.
-- An **Azure Storage Account** and a file share to store JSON files representing the **Dataspace Registry** across multiple participants.
 
 ## Initializing an Azure environment for CD
 
@@ -86,13 +85,11 @@ Configure the following GitHub secrets:
 | ----------------------------- | ------------------------------------------------------------ |
 | `ARM_TENANT_ID`               | The Azure AD tenant ID.                                      |
 | `ARM_SUBSCRIPTION_ID`         | The Azure subscription ID to deploy resources in.            |
-| `COMMON_RESOURCE_GROUP`          | The Azure resource group name to deploy common resources in, such as Azure Container Registry and Dataspace Registry storage account. |
+| `COMMON_RESOURCE_GROUP`          | The Azure resource group name to deploy common resources in, such as Azure Container Registry. |
 | `COMMON_RESOURCE_GROUP_LOCATION` | The location of the Azure resource group name to deploy common resources in. Example: `northeurope`. |
 | `ACR_NAME`                    | The name of the Azure Container Registry to deploy. Use only lowercase letters and numbers. |
 | `TERRAFORM_STATE_STORAGE_ACCOUNT` | The name of the storage account used to store the Terraform state container. |
 | `TERRAFORM_STATE_CONTAINER` | The name of the container used to store the Terraform state blob. |
-| `REGISTRY_STORAGE_ACCOUNT` | The name of the storage account used to store the Dataspace Registry file share. |
-| `REGISTRY_SHARE` | The name of the file share used to store the Dataspace Registry files. |
 
 Update the value of the `CD_RESOURCES_PREFIX` env in the [cd.yaml](../../.github/workflows/cd.yaml) file.
 This prefix should help have unique resource names across fork repositories when running CD workflow.


### PR DESCRIPTION
Use Registration Service to register participants.
- Updates repo dependency to use `RegistrationServiceFork`, and updated version. Improved workflow to avoid double checkout of `RegistrationServiceFork`.
- Removed code using file-based participant registry

Relates to #186 