### PR TITLE
Spike/25 gaiax sdd

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -278,7 +278,7 @@ jobs:
           output_file: deployment/terraform/participant/WrappedParticipantSelfDescription.json
           strict: true
           variables: |
-            registrationNumber=${{ matrix.registrationNumber }}
+            registrationNumber=${{ matrix.registration_number }}
             country=${{ matrix.country }}
 
       - name: 'Output GAIA-X self-description signature request'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -146,6 +146,29 @@ jobs:
           openssl ec -in key.pem -pubout -out key.public.pem
           docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < key.public.pem > key.public.jwk
 
+      - name: 'Prepare GAIA-X self-description signature request'
+        uses: cuchi/jinja2-action@v1.2.0
+        with:
+          template: deployment/terraform/dataspace/WrappedParticipantSelfDescription.json.j2
+          output_file: deployment/terraform/dataspace/WrappedParticipantSelfDescription.json
+          strict: true
+          variables: |
+            registrationNumber=A999999
+            country=NL
+
+      - name: 'Request GAIA-X self-description signature'
+        run: |
+          curl --fail --location 'https://compliance.gaia-x.eu/api/v1/participant/signature/sign' \
+          --header 'Content-Type: application/json' \
+          --data @WrappedParticipantSelfDescription.json \
+          --output SignedWrappedParticipantSelfDescription.json
+
+      - name: 'Verify GAIA-X self-description signature'
+        run: |
+          curl --fail --location 'https://compliance.gaia-x.eu/api/v1/participant/verify/raw' \
+          --header 'Content-Type: application/json' \
+          --data @SignedWrappedParticipantSelfDescription.json
+
       - name: 'Create tfvars file'
         run: |
           cat > terraform.tfvars <<EOF
@@ -196,6 +219,7 @@ jobs:
           # Terraform variables not included in terraform.tfvars.
           TF_VAR_key_file: "key.pem"
           TF_VAR_public_key_jwk_file: "key.public.jwk"
+          TF_VAR_self_description_file: "SignedWrappedParticipantSelfDescription.json"
 
       - name: 'Verify did endpoint is available'
         run: curl https://${{ steps.runterraform.outputs.did_host }}/.well-known/did.json | jq '.id'
@@ -246,6 +270,29 @@ jobs:
           openssl ecparam -name prime256v1 -genkey -noout -out key.pem
           openssl ec -in key.pem -pubout -out key.public.pem
           docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < key.public.pem > key.public.jwk
+          
+      - name: 'Prepare GAIA-X self-description signature request'
+        uses: cuchi/jinja2-action@v1.2.0
+        with:
+          template: deployment/terraform/participant/WrappedParticipantSelfDescription.json.j2
+          output_file: deployment/terraform/participant/WrappedParticipantSelfDescription.json
+          strict: true
+          variables: |
+            registrationNumber=${{ matrix.registrationNumber }}
+            country=${{ matrix.country }}
+
+      - name: 'Request GAIA-X self-description signature'
+        run: |
+          curl --fail --location 'https://compliance.gaia-x.eu/api/v1/participant/signature/sign' \
+          --header 'Content-Type: application/json' \
+          --data @WrappedParticipantSelfDescription.json \
+          --output SignedWrappedParticipantSelfDescription.json
+
+      - name: 'Verify GAIA-X self-description signature'
+        run: |
+          curl --fail --location 'https://compliance.gaia-x.eu/api/v1/participant/verify/raw' \
+          --header 'Content-Type: application/json' \
+          --data @SignedWrappedParticipantSelfDescription.json
 
       - name: 'Create tfvars file'
         run: |
@@ -317,6 +364,7 @@ jobs:
           # Terraform variables not included in terraform.tfvars.
           TF_VAR_key_file: "key.pem"
           TF_VAR_public_key_jwk_file: "key.public.jwk"
+          TF_VAR_self_description_file: "SignedWrappedParticipantSelfDescription.json"
           TF_VAR_application_sp_client_secret: ${{ secrets.APP_CLIENT_SECRET }}
           TF_VAR_app_insights_connection_string: ${{ needs.Deploy-Dataspace.outputs.app_insights_connection_string }}
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -281,6 +281,9 @@ jobs:
             registrationNumber=${{ matrix.registrationNumber }}
             country=${{ matrix.country }}
 
+      - name: 'Output GAIA-X self-description signature request'
+        run: cat WrappedParticipantSelfDescription.json
+
       - name: 'Request GAIA-X self-description signature'
         run: |
           curl --fail --location 'https://compliance.gaia-x.eu/api/v1/participant/signature/sign' \

--- a/deployment/terraform/dataspace/WrappedParticipantSelfDescription.json.j2
+++ b/deployment/terraform/dataspace/WrappedParticipantSelfDescription.json.j2
@@ -1,0 +1,36 @@
+{
+  "selfDescription": {
+    "@context": {
+      "sh": "http://www.w3.org/ns/shacl#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "gx-participant": "http://w3id.org/gaia-x/participant#"
+    },
+    "@type": "gx-participant:LegalPerson",
+    "@id": "http://example.org/participant-{{ registrationNumber }}",
+    "gx-participant:registrationNumber": {
+      "@type": "xsd:string",
+      "@value": "{{ registrationNumber }}"
+    },
+    "gx-participant:legalAddress": {
+      "@type": "gx-participant:Address",
+      "gx-participant:country": {
+        "@type": "xsd:string",
+        "@value": "{{ country }}"
+      }
+    },
+    "gx-participant:headquarterAddress": {
+      "@type": "gx-participant:Address",
+      "gx-participant:country": {
+        "@type": "xsd:string",
+        "@value": "{{ country }}"
+      }
+    }
+  },
+  "proof": {
+    "created": "2022-04-21T15:59:15Z",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "zGwuJiP42jZq2sMFG8K9t2x9dJX73Ky6pek8pUki6yuDqriQgLUVDxGyVhLY2TNwe656BB4qaZZE5SeqCWeMVxWs",
+    "type": "Ed25519Signature2020",
+    "verificationMethod": "did:web:vc.gaia-x.eu:issuer#Ed25519VerificationKey2020"
+  }
+}

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -170,3 +170,13 @@ resource "azurerm_storage_blob" "did" {
   content_type = "application/json"
 }
 
+resource "azurerm_storage_blob" "sdd" {
+  name                 = ".well-known/sdd.json"
+  storage_account_name = azurerm_storage_account.did.name
+  # Create sdd blob only if self_description_file is provided. Default self_description_file value is null.
+  count                  = var.self_description_file == null ? 0 : 1
+  storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
+  type                   = "Block"
+  source_content         = file(var.self_description_file)
+  content_type           = "application/json"
+}

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -44,3 +44,8 @@ variable "public_key_jwk_file" {
   description = "name of a file containing the public key in JWK format"
   default     = null
 }
+
+variable "self_description_file" {
+  description = "name of a file containing the GAIA-X self-description document"
+  default     = null
+}

--- a/deployment/terraform/participant/WrappedParticipantSelfDescription.json.j2
+++ b/deployment/terraform/participant/WrappedParticipantSelfDescription.json.j2
@@ -1,0 +1,36 @@
+{
+  "selfDescription": {
+    "@context": {
+      "sh": "http://www.w3.org/ns/shacl#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "gx-participant": "http://w3id.org/gaia-x/participant#"
+    },
+    "@type": "gx-participant:LegalPerson",
+    "@id": "http://example.org/participant-{{ registrationNumber }}",
+    "gx-participant:registrationNumber": {
+      "@type": "xsd:string",
+      "@value": "{{ registrationNumber }}"
+    },
+    "gx-participant:legalAddress": {
+      "@type": "gx-participant:Address",
+      "gx-participant:country": {
+        "@type": "xsd:string",
+        "@value": "{{ country }}"
+      }
+    },
+    "gx-participant:headquarterAddress": {
+      "@type": "gx-participant:Address",
+      "gx-participant:country": {
+        "@type": "xsd:string",
+        "@value": "{{ country }}"
+      }
+    }
+  },
+  "proof": {
+    "created": "2022-04-21T15:59:15Z",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "zGwuJiP42jZq2sMFG8K9t2x9dJX73Ky6pek8pUki6yuDqriQgLUVDxGyVhLY2TNwe656BB4qaZZE5SeqCWeMVxWs",
+    "type": "Ed25519Signature2020",
+    "verificationMethod": "did:web:vc.gaia-x.eu:issuer#Ed25519VerificationKey2020"
+  }
+}

--- a/deployment/terraform/participant/main.tf
+++ b/deployment/terraform/participant/main.tf
@@ -316,6 +316,17 @@ resource "azurerm_storage_blob" "did" {
   content_type = "application/json"
 }
 
+resource "azurerm_storage_blob" "sdd" {
+  name                 = ".well-known/sdd.json"
+  storage_account_name = azurerm_storage_account.did.name
+  # Create sdd blob only if self_description_file is provided. Default self_description_file value is null.
+  count                  = var.self_description_file == null ? 0 : 1
+  storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
+  type                   = "Block"
+  source_content         = file(var.self_description_file)
+  content_type           = "application/json"
+}
+
 resource "local_file" "registry_entry" {
   content = jsonencode({
     # `name` must be identical to EDC connector EDC_CONNECTOR_NAME setting for catalog asset filtering to

--- a/deployment/terraform/participant/variables.tf
+++ b/deployment/terraform/participant/variables.tf
@@ -71,6 +71,11 @@ variable "public_key_jwk_file" {
   default     = null
 }
 
+variable "self_description_file" {
+  description = "name of a file containing the GAIA-X self-description document"
+  default     = null
+}
+
 variable "registration_service_api_url" {
   description = "registration api url"
 }

--- a/participants.json
+++ b/participants.json
@@ -17,7 +17,7 @@
     {
       "participant": "company3",
       "registrationNumber": "000003",
-      "country": "US",
+      "country": "CH",
       "region": "us",
       "data_dashboard_theme": "theme-3"
     }

--- a/participants.json
+++ b/participants.json
@@ -2,16 +2,22 @@
   "include": [
     {
       "participant": "company1",
+      "registrationNumber": "000001",
+      "country": "DE",
       "region": "eu",
       "data_dashboard_theme": "theme-1"
     },
     {
       "participant": "company2",
+      "registrationNumber": "000002",
+      "country": "FR",
       "region": "eu",
       "data_dashboard_theme": "theme-2"
     },
     {
       "participant": "company3",
+      "registrationNumber": "000003",
+      "country": "US",
       "region": "us",
       "data_dashboard_theme": "theme-3"
     }

--- a/participants.json
+++ b/participants.json
@@ -2,21 +2,21 @@
   "include": [
     {
       "participant": "company1",
-      "registrationNumber": "000001",
+      "registration_number": "000001",
       "country": "DE",
       "region": "eu",
       "data_dashboard_theme": "theme-1"
     },
     {
       "participant": "company2",
-      "registrationNumber": "000002",
+      "registration_number": "000002",
       "country": "FR",
       "region": "eu",
       "data_dashboard_theme": "theme-2"
     },
     {
       "participant": "company3",
-      "registrationNumber": "000003",
+      "registration_number": "000003",
       "country": "CH",
       "region": "us",
       "data_dashboard_theme": "theme-3"


### PR DESCRIPTION
Deploy self-description document (SDD).

Generates, signs (through GAIA-X compliance server) and uploads the SDD as public static document:
- For dataspace authority e.g. https://mvd17did.z16.web.core.windows.net/.well-known/sdd.json
- For each of the 3 participating companies

The SDD contains a participant number (`A999999`, `000001`, `000002`, `000003`) and a country (`NL`, `DE`, `FR`, `CH`). `CH` is used instead of `US` as GAIA-X server rejects requests with that country.

Relates to #25 