### PR TITLE
Deploy Gaia-X Authority did document

### DIFF
--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -10,7 +10,8 @@ runs:
   using: "composite"
   steps:
     - name: 'Generate GAIA-X Authority key'
-      shell: bash
+      uses: actions/checkout@v2
+      working-directory: deployment/terraform/dataspace
       run: |
         openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyname }}.pem
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -3,7 +3,7 @@ description: "Generate key"
 
 inputs:
   keyname:
-    description: 'Name of the key used as key file name'
+    description: 'Name of the key file name'
     required: true
 
 runs:

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -7,8 +7,7 @@ inputs:
     required: true
   directory:
     description: 'Path to a directory where the key should be saved.'
-    default: 'deployment/terraform/dataspace'
-    required: false
+    required: true
 
 runs:
   using: "composite"

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -11,7 +11,6 @@ runs:
   steps:
     - name: 'Generate GAIA-X Authority key'
       run: |
-        pwd
         openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyname }}.pem
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem
         docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyname }}.public.pem > ${{ inputs.keyname }}.public.jwk

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   directory:
     description: 'Path to a directory where the key should be saved.'
-    default: deployment/terraform/dataspace
+    default: 'deployment/terraform/dataspace'
     required: false
 
 runs:

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -16,4 +16,3 @@ runs:
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem
         docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyname }}.public.pem > ${{ inputs.keyname }}.public.jwk
       shell: bash
-      working-directory: deployment/terraform/dataspace

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -11,7 +11,6 @@ runs:
   steps:
     - name: 'Generate GAIA-X Authority key'
       uses: actions/checkout@v2
-      working-directory: deployment/terraform/dataspace
       run: |
         openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyname }}.pem
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -1,4 +1,4 @@
-name: "Generate key"
+name: "Generate keys"
 description: "Generate openssl public and private keys"
 
 inputs:

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -16,3 +16,4 @@ runs:
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem
         docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyname }}.public.pem > ${{ inputs.keyname }}.public.jwk
       shell: bash
+      working-directory: deployment/terraform/dataspace

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -7,15 +7,16 @@ inputs:
     required: true
   directory:
     description: 'Path to a directory where the key should be saved.'
-    required: true
+    default: deployment/terraform/dataspace
+    required: false
 
 runs:
   using: "composite"
   steps:
     - name: 'Generate key'
       run: |
-        openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyname }}.pem
-        openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem
-        docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyname }}.public.pem > ${{ inputs.keyname }}.public.jwk
+        openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyFileNamePrefix }}.pem
+        openssl ec -in ${{ inputs.keyFileNamePrefix }}.pem -pubout -out ${{ inputs.keyFileNamePrefix }}.public.pem
+        docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyFileNamePrefix }}.public.pem > ${{ inputs.keyFileNamePrefix }}.public.jwk
       shell: bash
       working-directory: ${{ inputs.directory }}

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -10,8 +10,9 @@ runs:
   using: "composite"
   steps:
     - name: 'Generate GAIA-X Authority key'
-      uses: actions/checkout@v2
       run: |
         openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyname }}.pem
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem
         docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyname }}.public.pem > ${{ inputs.keyname }}.public.jwk
+      shell: bash
+      working-directory: deployment/terraform/dataspace

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -1,0 +1,17 @@
+name: "Generate key"
+description: "Generate key"
+
+inputs:
+  keyname:
+    description: 'Name of the key used as key file name'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: 'Generate GAIA-X Authority key'
+      shell: bash
+      run: |
+        openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyname }}.pem
+        openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem
+        docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyname }}.public.pem > ${{ inputs.keyname }}.public.jwk

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -11,6 +11,7 @@ runs:
   steps:
     - name: 'Generate GAIA-X Authority key'
       run: |
+        pwd
         openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyname }}.pem
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem
         docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyname }}.public.pem > ${{ inputs.keyname }}.public.jwk

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -1,9 +1,9 @@
 name: "Generate key"
-description: "Generate key"
+description: "Generate openssl public and private keys"
 
 inputs:
-  keyname:
-    description: 'Name of the key file name.'
+  keyFileNamePrefix:
+    description: 'Prefix of the key file name.'
     required: true
   directory:
     description: 'Path to a directory where the key should be saved.'
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: 'Generate GAIA-X Authority key'
+    - name: 'Generate key'
       run: |
         openssl ecparam -name prime256v1 -genkey -noout -out ${{ inputs.keyname }}.pem
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem

--- a/.github/actions/generate-key/action.yml
+++ b/.github/actions/generate-key/action.yml
@@ -3,8 +3,12 @@ description: "Generate key"
 
 inputs:
   keyname:
-    description: 'Name of the key file name'
+    description: 'Name of the key file name.'
     required: true
+  directory:
+    description: 'Path to a directory where the key should be saved.'
+    default: deployment/terraform/dataspace
+    required: false
 
 runs:
   using: "composite"
@@ -15,4 +19,4 @@ runs:
         openssl ec -in ${{ inputs.keyname }}.pem -pubout -out ${{ inputs.keyname }}.public.pem
         docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < ${{ inputs.keyname }}.public.pem > ${{ inputs.keyname }}.public.jwk
       shell: bash
-      working-directory: deployment/terraform/dataspace
+      working-directory: ${{ inputs.directory }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,8 +1,9 @@
 name: CD
 
 on:
+  push:
   pull_request:
-    branches: [ main, feature/151-gaiax-did ]
+    branches: [ main ]
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,7 +2,6 @@ name: CD
 
 on:
   pull_request:
-    branches: [ main ]
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, feature/151-gaiax-did ]
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,7 +1,6 @@
 name: CD
 
 on:
-  push:
   pull_request:
     branches: [ main ]
     paths-ignore:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -204,11 +204,11 @@ jobs:
           TF_VAR_public_key_jwk_file_registry: "registrationservicekey.public.jwk"
           TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
 
-      - name: 'Verify Registration Service did endpoint is available'
-        run: curl https://${{ steps.runterraform.outputs.registry_did_host }}/.well-known/did.json | jq '.id'
-
       - name: 'Verify GAIA-X Authority did endpoint is available'
         run: curl https://${{ steps.runterraform.outputs.gaiax_did_host }}/.well-known/did.json | jq '.id'
+
+      - name: 'Verify Registration Service did endpoint is available'
+        run: curl https://${{ steps.runterraform.outputs.registry_did_host }}/.well-known/did.json | jq '.id'
 
       - name: 'Verify deployed Registry Service is healthy'
         run: curl --retry 6 --fail ${{ steps.runterraform.outputs.registration_service_url }}/api/check/health

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -251,11 +251,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: 'Generate key'
-        run: |
-          openssl ecparam -name prime256v1 -genkey -noout -out key.pem
-          openssl ec -in key.pem -pubout -out key.public.pem
-          docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < key.public.pem > key.public.jwk
+      - name: 'Generate Participant's key'
+        uses: ./.github/actions/generate-key
+        with:
+          keyname: key
 
       - name: 'Create tfvars file'
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -140,17 +140,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: 'Generate Registration Service key'
-        run: |
-          openssl ecparam -name prime256v1 -genkey -noout -out registrykey.pem
-          openssl ec -in registrykey.pem -pubout -out registrykey.public.pem
-          docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < registrykey.public.pem > registrykey.public.jwk
-
       - name: 'Generate GAIA-X Authority key'
-        run: |
-          openssl ecparam -name prime256v1 -genkey -noout -out gaiaxkey.pem
-          openssl ec -in gaiaxkey.pem -pubout -out gaiaxkey.public.pem
-          docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < gaiaxkey.public.pem > gaiaxkey.public.jwk
+        uses: ./.github/actions/generate-key
+        with:
+          keyname: gaiaxkey
+
+      - name: 'Generate Dataspace Authority key'
+        uses: ./.github/actions/generate-key
+        with:
+          keyname: registrationservicekey
 
       - name: 'Create tfvars file'
         run: |
@@ -202,8 +200,8 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           # Terraform variables not included in terraform.tfvars.
-          TF_VAR_key_file_registry: "registrykey.pem"
-          TF_VAR_public_key_jwk_file_registry: "registrykey.public.jwk"
+          TF_VAR_key_file_registry: "registrationservicekey.pem"
+          TF_VAR_public_key_jwk_file_registry: "registrationservicekey.public.jwk"
           TF_VAR_key_file_gaiax: "gaiaxkey.pem"
           TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -202,7 +202,6 @@ jobs:
           # Terraform variables not included in terraform.tfvars.
           TF_VAR_key_file_registry: "registrationservicekey.pem"
           TF_VAR_public_key_jwk_file_registry: "registrationservicekey.public.jwk"
-          TF_VAR_key_file_gaiax: "gaiaxkey.pem"
           TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
 
       - name: 'Verify Registration Service did endpoint is available'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -144,13 +144,11 @@ jobs:
         uses: ./.github/actions/generate-key
         with:
           keyFileNamePrefix: gaiaxkey
-          directory: deployment/terraform/dataspace
 
       - name: 'Generate Dataspace Authority key'
         uses: ./.github/actions/generate-key
         with:
           keyFileNamePrefix: authoritykey
-          directory: deployment/terraform/dataspace
 
       - name: 'Create tfvars file'
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -148,9 +148,9 @@ jobs:
 
       - name: 'Generate GAIA-X Authority key'
         run: |
-        openssl ecparam -name prime256v1 -genkey -noout -out gaiaxkey.pem
-        openssl ec -in gaiaxkey.pem -pubout -out gaiaxkey.public.pem
-        docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < gaiaxkey.public.pem > gaiaxkey.public.jwk
+          openssl ecparam -name prime256v1 -genkey -noout -out gaiaxkey.pem
+          openssl ec -in gaiaxkey.pem -pubout -out gaiaxkey.public.pem
+          docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < gaiaxkey.public.pem > gaiaxkey.public.jwk
 
       - name: 'Create tfvars file'
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -143,12 +143,12 @@ jobs:
       - name: 'Generate GAIA-X Authority key'
         uses: ./.github/actions/generate-key
         with:
-          keyname: gaiaxkey
+          keyFileNamePrefix: gaiaxkey
 
       - name: 'Generate Dataspace Authority key'
         uses: ./.github/actions/generate-key
         with:
-          keyname: registrationservicekey
+          keyFileNamePrefix: authoritykey
 
       - name: 'Create tfvars file'
         run: |
@@ -200,8 +200,8 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           # Terraform variables not included in terraform.tfvars.
-          TF_VAR_key_file_authority: "registrationservicekey.pem"
-          TF_VAR_public_key_jwk_file_authority: "registrationservicekey.public.jwk"
+          TF_VAR_key_file_authority: "authoritykey.pem"
+          TF_VAR_public_key_jwk_file_authority: "authoritykey.public.jwk"
           TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
 
       - name: 'Verify GAIA-X Authority did endpoint is available'
@@ -254,7 +254,7 @@ jobs:
       - name: 'Generate Participant key'
         uses: ./.github/actions/generate-key
         with:
-          keyname: key
+          keyFileNamePrefix: key
           directory: deployment/terraform/participant
 
       - name: 'Create tfvars file'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -140,11 +140,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: 'Generate key'
+      - name: 'Generate Registration Service key'
         run: |
-          openssl ecparam -name prime256v1 -genkey -noout -out key.pem
-          openssl ec -in key.pem -pubout -out key.public.pem
-          docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < key.public.pem > key.public.jwk
+          openssl ecparam -name prime256v1 -genkey -noout -out registrykey.pem
+          openssl ec -in registrykey.pem -pubout -out registrykey.public.pem
+          docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < registrykey.public.pem > registrykey.public.jwk
+
+      - name: 'Generate GAIA-X Authority key'
+        run: |
+        openssl ecparam -name prime256v1 -genkey -noout -out gaiaxkey.pem
+        openssl ec -in gaiaxkey.pem -pubout -out gaiaxkey.public.pem
+        docker run -i danedmunds/pem-to-jwk:1.2.1 --public --pretty < gaiaxkey.public.pem > gaiaxkey.public.jwk
 
       - name: 'Create tfvars file'
         run: |
@@ -183,8 +189,10 @@ jobs:
           echo "::set-output name=app_insights_connection_string::${app_insights_connection_string}"
           registration_service_url=$(terraform output -raw registration_service_url)
           echo "::set-output name=registration_service_url::${registration_service_url}"
-          did_host=$(terraform output -raw did_host)
-          echo "::set-output name=did_host::${did_host}"
+          registry_did_host=$(terraform output -raw registry_did_host)
+          echo "::set-output name=registry_did_host::${registry_did_host}"
+          gaiax_did_host=$(terraform output -raw gaiax_did_host)
+          echo "::set-output name=gaiax_did_host::${gaiax_did_host}"
 
         env:
           # Authentication settings for Terraform AzureRM provider
@@ -194,11 +202,16 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           # Terraform variables not included in terraform.tfvars.
-          TF_VAR_key_file: "key.pem"
-          TF_VAR_public_key_jwk_file: "key.public.jwk"
+          TF_VAR_key_file_registry: "registrykey.pem"
+          TF_VAR_public_key_jwk_file_registry: "registrykey.public.jwk"
+          TF_VAR_key_file_gaiax: "gaiaxkey.pem"
+          TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
 
-      - name: 'Verify did endpoint is available'
-        run: curl https://${{ steps.runterraform.outputs.did_host }}/.well-known/did.json | jq '.id'
+      - name: 'Verify Registration Service did endpoint is available'
+        run: curl https://${{ steps.runterraform.outputs.registry_did_host }}/.well-known/did.json | jq '.id'
+
+      - name: 'Verify GAIA-X Authority did endpoint is available'
+        run: curl https://${{ steps.runterraform.outputs.gaiax_did_host }}/.well-known/did.json | jq '.id'
 
       - name: 'Verify deployed Registry Service is healthy'
         run: curl --retry 6 --fail ${{ steps.runterraform.outputs.registration_service_url }}/api/check/health

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -144,11 +144,13 @@ jobs:
         uses: ./.github/actions/generate-key
         with:
           keyFileNamePrefix: gaiaxkey
+          directory: deployment/terraform/dataspace
 
       - name: 'Generate Dataspace Authority key'
         uses: ./.github/actions/generate-key
         with:
           keyFileNamePrefix: authoritykey
+          directory: deployment/terraform/dataspace
 
       - name: 'Create tfvars file'
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -157,7 +157,7 @@ jobs:
           acr_name = "${{ secrets.ACR_NAME }}"
           prefix = "${{ env.RESOURCES_PREFIX }}"
           resource_group = "rg-${{ env.RESOURCES_PREFIX }}"
-          registry_runtime_image = "mvd/registration-service:${{ env.RESOURCES_PREFIX }}"
+          registrationservice_runtime_image = "mvd/registration-service:${{ env.RESOURCES_PREFIX }}"
           application_sp_object_id = "${{ secrets.APP_OBJECT_ID }}"
           EOF
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -187,8 +187,8 @@ jobs:
           echo "::set-output name=app_insights_connection_string::${app_insights_connection_string}"
           registration_service_url=$(terraform output -raw registration_service_url)
           echo "::set-output name=registration_service_url::${registration_service_url}"
-          registry_did_host=$(terraform output -raw registry_did_host)
-          echo "::set-output name=registry_did_host::${registry_did_host}"
+          authority_did_host=$(terraform output -raw authority_did_host)
+          echo "::set-output name=authority_did_host::${authority_did_host}"
           gaiax_did_host=$(terraform output -raw gaiax_did_host)
           echo "::set-output name=gaiax_did_host::${gaiax_did_host}"
 
@@ -200,15 +200,15 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           # Terraform variables not included in terraform.tfvars.
-          TF_VAR_key_file_registry: "registrationservicekey.pem"
-          TF_VAR_public_key_jwk_file_registry: "registrationservicekey.public.jwk"
+          TF_VAR_key_file_authority: "registrationservicekey.pem"
+          TF_VAR_public_key_jwk_file_authority: "registrationservicekey.public.jwk"
           TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
 
       - name: 'Verify GAIA-X Authority did endpoint is available'
         run: curl https://${{ steps.runterraform.outputs.gaiax_did_host }}/.well-known/did.json | jq '.id'
 
-      - name: 'Verify Registration Service did endpoint is available'
-        run: curl https://${{ steps.runterraform.outputs.registry_did_host }}/.well-known/did.json | jq '.id'
+      - name: 'Verify Dataspace Authority did endpoint is available'
+        run: curl https://${{ steps.runterraform.outputs.authority_did_host }}/.well-known/did.json | jq '.id'
 
       - name: 'Verify deployed Registry Service is healthy'
         run: curl --retry 6 --fail ${{ steps.runterraform.outputs.registration_service_url }}/api/check/health

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -251,10 +251,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: 'Generate Participant's key'
+      - name: 'Generate Participant key'
         uses: ./.github/actions/generate-key
         with:
           keyname: key
+          directory: deployment/terraform/participant
 
       - name: 'Create tfvars file'
         run: |

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -96,7 +96,7 @@ resource "azurerm_container_group" "registration-service" {
 
 resource "azurerm_key_vault" "registrationservice" {
   // added `kv` prefix because the keyvault name needs to begin with a letter
-  name                        = "kv${var.prefix}registrationservice"
+  name                        = "kv${var.prefix}registration"
   location                    = var.location
   resource_group_name         = azurerm_resource_group.dataspace.name
   enabled_for_disk_encryption = false

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -160,14 +160,14 @@ resource "azurerm_storage_blob" "authority_did" {
     ],
     "verificationMethod" = [
       {
-        "id"           = "#identity-key-registration-service"
+        "id"           = "#identity-key-authority"
         "controller"   = ""
         "type"         = "JsonWebKey2020"
         "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file_authority))
       }
     ],
     "authentication" : [
-      "#identity-key-registration-service"
+      "#identity-key-authority"
   ] })
   content_type = "application/json"
 }

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -41,7 +41,7 @@ locals {
   edc_default_port               = 8181
 
   registry_did_url = "did:web:${azurerm_storage_account.registry_did.primary_web_host}"
-  gaiax_did_url = "did:web:${azurerm_storage_account.gaiax_did.primary_web_host}"
+  gaiax_did_url    = "did:web:${azurerm_storage_account.gaiax_did.primary_web_host}"
 }
 
 resource "azurerm_resource_group" "dataspace" {
@@ -208,7 +208,7 @@ resource "azurerm_storage_blob" "gaiax_did" {
     ],
     "authentication" : [
       "#identity-key-gaiax"
-    ] })
+  ] })
   content_type = "application/json"
 }
 

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -41,7 +41,7 @@ locals {
   edc_default_port               = 8181
 
   authority_did_url = "did:web:${azurerm_storage_account.authority_did.primary_web_host}"
-  gaiax_did_url    = "did:web:${azurerm_storage_account.gaiax_did.primary_web_host}"
+  gaiax_did_url     = "did:web:${azurerm_storage_account.gaiax_did.primary_web_host}"
 }
 
 resource "azurerm_resource_group" "dataspace" {

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -132,7 +132,7 @@ resource "azurerm_storage_account" "authority_did" {
   static_website {}
 }
 
-resource "azurerm_key_vault_secret" "did_key" {
+resource "azurerm_key_vault_secret" "authority_did_key" {
   name = local.connector_name
   # Create did_key secret only if key_file value is provided. Default key_file value is null.
   count        = var.key_file_authority == null ? 0 : 1

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -27,7 +27,7 @@ data "azurerm_subscription" "current_subscription" {
 data "azurerm_client_config" "current_client" {
 }
 
-data "azurerm_container_registry" "registry" {
+data "azurerm_container_registry" "registrationservice" {
   name                = var.acr_name
   resource_group_name = var.acr_resource_group
 }
@@ -40,7 +40,7 @@ locals {
   registration_service_dns_label = "${var.prefix}-registration-mvd"
   edc_default_port               = 8181
 
-  registry_did_url = "did:web:${azurerm_storage_account.registry_did.primary_web_host}"
+  authority_did_url = "did:web:${azurerm_storage_account.authority_did.primary_web_host}"
   gaiax_did_url    = "did:web:${azurerm_storage_account.gaiax_did.primary_web_host}"
 }
 
@@ -65,14 +65,14 @@ resource "azurerm_container_group" "registration-service" {
   os_type             = "Linux"
 
   image_registry_credential {
-    username = data.azurerm_container_registry.registry.admin_username
-    password = data.azurerm_container_registry.registry.admin_password
-    server   = data.azurerm_container_registry.registry.login_server
+    username = data.azurerm_container_registry.registrationservice.admin_username
+    password = data.azurerm_container_registry.registrationservice.admin_password
+    server   = data.azurerm_container_registry.registrationservice.login_server
   }
 
   container {
     name   = "registration-service"
-    image  = "${data.azurerm_container_registry.registry.login_server}/${var.registry_runtime_image}"
+    image  = "${data.azurerm_container_registry.registrationservice.login_server}/${var.registrationservice_runtime_image}"
     cpu    = var.container_cpu
     memory = var.container_memory
 
@@ -94,9 +94,9 @@ resource "azurerm_container_group" "registration-service" {
   }
 }
 
-resource "azurerm_key_vault" "registry" {
+resource "azurerm_key_vault" "registrationservice" {
   // added `kv` prefix because the keyvault name needs to begin with a letter
-  name                        = "kv${var.prefix}-registry"
+  name                        = "kv${var.prefix}-registrationservice"
   location                    = var.location
   resource_group_name         = azurerm_resource_group.dataspace.name
   enabled_for_disk_encryption = false
@@ -108,22 +108,22 @@ resource "azurerm_key_vault" "registry" {
 }
 
 # Role assignment so that the application may access the vault
-resource "azurerm_role_assignment" "registry_keyvault" {
-  scope                = azurerm_key_vault.registry.id
+resource "azurerm_role_assignment" "registrationservice_keyvault" {
+  scope                = azurerm_key_vault.registrationservice.id
   role_definition_name = "Key Vault Secrets Officer"
   principal_id         = var.application_sp_object_id
 }
 
 # Role assignment so that the currently logged in user may add secrets to the vault
 resource "azurerm_role_assignment" "current-user-secretsofficer" {
-  scope                = azurerm_key_vault.registry.id
+  scope                = azurerm_key_vault.registrationservice.id
   role_definition_name = "Key Vault Secrets Officer"
   principal_id         = data.azurerm_client_config.current_client.object_id
 }
 
 # Registration Service resources
-resource "azurerm_storage_account" "registry_did" {
-  name                     = "${var.prefix}registrydid"
+resource "azurerm_storage_account" "authority_did" {
+  name                     = "${var.prefix}authoritydid"
   resource_group_name      = azurerm_resource_group.dataspace.name
   location                 = var.location
   account_tier             = "Standard"
@@ -135,27 +135,27 @@ resource "azurerm_storage_account" "registry_did" {
 resource "azurerm_key_vault_secret" "did_key" {
   name = local.connector_name
   # Create did_key secret only if key_file value is provided. Default key_file value is null.
-  count        = var.key_file_registry == null ? 0 : 1
-  value        = file(var.key_file_registry)
-  key_vault_id = azurerm_key_vault.registry.id
+  count        = var.key_file_authority == null ? 0 : 1
+  value        = file(var.key_file_authority)
+  key_vault_id = azurerm_key_vault.registrationservice.id
   depends_on = [
     azurerm_role_assignment.current-user-secretsofficer
   ]
 }
 
-resource "azurerm_storage_blob" "registry_did" {
+resource "azurerm_storage_blob" "authority_did" {
   name                 = ".well-known/did.json" # `.well-known` path is defined by did:web specification
-  storage_account_name = azurerm_storage_account.registry_did.name
+  storage_account_name = azurerm_storage_account.authority_did.name
   # Create did blob only if public_key_jwk_file is provided. Default public_key_jwk_file value is null.
-  count                  = var.public_key_jwk_file_registry == null ? 0 : 1
+  count                  = var.public_key_jwk_file_authority == null ? 0 : 1
   storage_container_name = "$web" # container used to serve static files (see static_website property on storage account)
   type                   = "Block"
   source_content = jsonencode({
-    id = local.registry_did_url
+    id = local.authority_did_url
     "@context" = [
       "https://www.w3.org/ns/did/v1",
       {
-        "@base" = local.registry_did_url
+        "@base" = local.authority_did_url
       }
     ],
     "verificationMethod" = [
@@ -163,7 +163,7 @@ resource "azurerm_storage_blob" "registry_did" {
         "id"           = "#identity-key-registration-service"
         "controller"   = ""
         "type"         = "JsonWebKey2020"
-        "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file_registry))
+        "publicKeyJwk" = jsondecode(file(var.public_key_jwk_file_authority))
       }
     ],
     "authentication" : [

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -96,7 +96,7 @@ resource "azurerm_container_group" "registration-service" {
 
 resource "azurerm_key_vault" "registrationservice" {
   // added `kv` prefix because the keyvault name needs to begin with a letter
-  name                        = "kv${var.prefix}-registrationservice"
+  name                        = "kv${var.prefix}registrationservice"
   location                    = var.location
   resource_group_name         = azurerm_resource_group.dataspace.name
   enabled_for_disk_encryption = false

--- a/deployment/terraform/dataspace/outputs.tf
+++ b/deployment/terraform/dataspace/outputs.tf
@@ -7,8 +7,8 @@ output "registration_service_url" {
   value = "http://${azurerm_container_group.registration-service.fqdn}:${local.edc_default_port}"
 }
 
-output "registry_did_host" {
-  value = length(azurerm_storage_blob.registry_did) > 0 ? azurerm_storage_account.registry_did.primary_web_host : null
+output "authority_did_host" {
+  value = length(azurerm_storage_blob.authority_did) > 0 ? azurerm_storage_account.authority_did.primary_web_host : null
 }
 
 output "gaiax_did_host" {

--- a/deployment/terraform/dataspace/outputs.tf
+++ b/deployment/terraform/dataspace/outputs.tf
@@ -7,6 +7,10 @@ output "registration_service_url" {
   value = "http://${azurerm_container_group.registration-service.fqdn}:${local.edc_default_port}"
 }
 
-output "did_host" {
-  value = length(azurerm_storage_blob.did) > 0 ? azurerm_storage_account.did.primary_web_host : null
+output "registry_did_host" {
+  value = length(azurerm_storage_blob.registry_did) > 0 ? azurerm_storage_account.registry_did.primary_web_host : null
+}
+
+output "gaiax_did_host" {
+  value = length(azurerm_storage_blob.gaiax_did) > 0 ? azurerm_storage_account.gaiax_did.primary_web_host : null
 }

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -35,12 +35,22 @@ variable "application_sp_object_id" {
   description = "object id of application's service principal object"
 }
 
-variable "key_file" {
-  description = "name of a file containing the private key in PEM format"
+variable "key_file_registry" {
+  description = "name of a file containing the Registration Service private key in PEM format"
   default     = null
 }
 
-variable "public_key_jwk_file" {
-  description = "name of a file containing the public key in JWK format"
+variable "key_file_gaiax" {
+  description = "name of a file containing the GAIA-X Authority Service private key in PEM format"
+  default     = null
+}
+
+variable "public_key_jwk_file_registry" {
+  description = "name of a file containing the Registration Service public key in JWK format"
+  default     = null
+}
+
+variable "public_key_jwk_file_gaiax" {
+  description = "name of a file containing the GAIA-X public key in JWK format"
   default     = null
 }

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -11,8 +11,8 @@ variable "resource_group" {
   default = "test-dataspace"
 }
 
-variable "registry_runtime_image" {
-  description = "Image name of the Registry Service to deploy."
+variable "registrationservice_runtime_image" {
+  description = "Image name of the Registration Service to deploy."
 }
 
 variable "acr_name" {
@@ -35,12 +35,12 @@ variable "application_sp_object_id" {
   description = "object id of application's service principal object"
 }
 
-variable "key_file_registry" {
+variable "key_file_authority" {
   description = "name of a file containing the Registration Service private key in PEM format"
   default     = null
 }
 
-variable "public_key_jwk_file_registry" {
+variable "public_key_jwk_file_authority" {
   description = "name of a file containing the Registration Service public key in JWK format"
   default     = null
 }

--- a/deployment/terraform/dataspace/variables.tf
+++ b/deployment/terraform/dataspace/variables.tf
@@ -40,11 +40,6 @@ variable "key_file_registry" {
   default     = null
 }
 
-variable "key_file_gaiax" {
-  description = "name of a file containing the GAIA-X Authority Service private key in PEM format"
-  default     = null
-}
-
 variable "public_key_jwk_file_registry" {
   description = "name of a file containing the Registration Service public key in JWK format"
   default     = null


### PR DESCRIPTION
Deployment of GAIA-X Authority DID in Deploy pipeline.
DID document contains public key in the same format as Registration Service did document. 

### Further notes

- renaming the `registry` to either `authority` for did document resources and `registrationservice` for Registration Service resources for consistency
- removing `branches: [ main ]` from CD workflow to enable checks in all PRs

linked to #151 
