### PR TITLE
Feature/56 Skip Azure resources deployment if Azure secrets are not set up 

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,7 +2,6 @@ name: CD
 
 on:
   pull_request:
-    branches: [ main ]
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       resources_prefix: ${{ env.CD_RESOURCES_PREFIX }}${{ github.run_number }}
 
-  # Temporary check that checks if the Azure secrets are set up. If not then the deploy of Azure resources will be skipped. Introduced to not fail PR checks from forks.
+  # Temporary step that checks if Azure secrets are set up. If not then the deploy of Azure resources will be skipped. Introduced to not fail checks in PRs from forks.
   Check-Cloud-Environments:
     name: 'Check if Azure secrets are set up'
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -38,8 +38,8 @@ jobs:
           HAS_AZURE: ${{ secrets.ARM_SUBSCRIPTION_ID }}
         if: "${{ env.HAS_AZURE != '' }}"
         run: echo "::set-output name=defined::true"
-      outputs:
-        has-azure: ${{ steps.has-azure.outputs.defined }}
+    outputs:
+      has-azure: ${{ steps.has-azure.outputs.defined }}
 
   Deploy:
     if: ${{ needs.Check-Cloud-Environments.outputs.has-azure == 'true' }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -30,20 +30,36 @@ jobs:
     outputs:
       resources_prefix: ${{ env.CD_RESOURCES_PREFIX }}${{ github.run_number }}
 
+  Check-Cloud-Environments:
+    name: 'Check if Azure secrets are set up'
+    runs-on: ubuntu-latest
+    steps:
+      - id: has-azure
+        env:
+          HAS_AZURE: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+        if: "${{ env.HAS_AZURE != '' }}"
+        run: echo "::set-output name=defined::true"
+      outputs:
+        has-azure: ${{ steps.has-azure.outputs.defined }}
+
   Deploy:
+    if: ${{ needs.Check-Cloud-Environments.outputs.has-azure == 'true' }}
     uses: ./.github/workflows/deploy.yaml
     secrets: inherit
-    needs: SetResourcesPrefix
+    needs:
+      - SetResourcesPrefix
+      - Check-Cloud-Environments
     with:
       resources_prefix: ${{ needs.SetResourcesPrefix.outputs.resources_prefix }}
 
   Destroy:
     # Always run Destroy workflow unless SetResourcesPrefix workflow fails.
-    if: ${{ always() && needs.SetResourcesPrefix.result == 'success'}}
+    if: ${{ always() && needs.SetResourcesPrefix.result == 'success' && needs.Check-Cloud-Environments.outputs.has-azure == 'true'}}
     uses: ./.github/workflows/destroy.yaml
     needs:
       - SetResourcesPrefix
       - Deploy
+      - Check-Cloud-Environments
     secrets: inherit
     with:
       resources_prefix: ${{ needs.SetResourcesPrefix.outputs.resources_prefix }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       resources_prefix: ${{ env.CD_RESOURCES_PREFIX }}${{ github.run_number }}
 
+  # Temporary check that checks if the Azure secrets are set up. If not then the deploy of Azure resources will be skipped. Introduced to not fail PR checks from forks.
   Check-Cloud-Environments:
     name: 'Check if Azure secrets are set up'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Linked to #56 

This PR introduces a step that checks if the repository has Azure secrets set up. If yes -> proceeds with the CD workflow, if not -> the checks are disabled.

The reason to introduce such step is to not fail the workflow in the PRs from forks to the upstream MVD repository.
Please note that it's a temporary solution. 
A solution that allows to run all tests (eg. on local resources) in PR from forks will be introduced at later stage. 