### PR TITLE
Rename 'registry' to 'registration service' consistently

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -204,10 +204,10 @@ jobs:
           TF_VAR_public_key_jwk_file_authority: "authoritykey.public.jwk"
           TF_VAR_public_key_jwk_file_gaiax: "gaiaxkey.public.jwk"
 
-      - name: 'Verify GAIA-X Authority did endpoint is available'
+      - name: 'Verify GAIA-X Authority DID endpoint is available'
         run: curl https://${{ steps.runterraform.outputs.gaiax_did_host }}/.well-known/did.json | jq '.id'
 
-      - name: 'Verify Dataspace Authority did endpoint is available'
+      - name: 'Verify Dataspace DID endpoint is available'
         run: curl https://${{ steps.runterraform.outputs.dataspace_did_host }}/.well-known/did.json | jq '.id'
 
       - name: 'Verify deployed Registration Service is healthy'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -187,8 +187,8 @@ jobs:
           echo "::set-output name=app_insights_connection_string::${app_insights_connection_string}"
           registration_service_url=$(terraform output -raw registration_service_url)
           echo "::set-output name=registration_service_url::${registration_service_url}"
-          authority_did_host=$(terraform output -raw authority_did_host)
-          echo "::set-output name=authority_did_host::${authority_did_host}"
+          dataspace_did_host=$(terraform output -raw dataspace_did_host)
+          echo "::set-output name=dataspace_did_host::${dataspace_did_host}"
           gaiax_did_host=$(terraform output -raw gaiax_did_host)
           echo "::set-output name=gaiax_did_host::${gaiax_did_host}"
 
@@ -208,9 +208,9 @@ jobs:
         run: curl https://${{ steps.runterraform.outputs.gaiax_did_host }}/.well-known/did.json | jq '.id'
 
       - name: 'Verify Dataspace Authority did endpoint is available'
-        run: curl https://${{ steps.runterraform.outputs.authority_did_host }}/.well-known/did.json | jq '.id'
+        run: curl https://${{ steps.runterraform.outputs.dataspace_did_host }}/.well-known/did.json | jq '.id'
 
-      - name: 'Verify deployed Registry Service is healthy'
+      - name: 'Verify deployed Registration Service is healthy'
         run: curl --retry 6 --fail ${{ steps.runterraform.outputs.registration_service_url }}/api/check/health
 
   # Deploy dataspace participants in parallel.

--- a/deployment/terraform/dataspace/outputs.tf
+++ b/deployment/terraform/dataspace/outputs.tf
@@ -7,8 +7,8 @@ output "registration_service_url" {
   value = "http://${azurerm_container_group.registration-service.fqdn}:${local.edc_default_port}"
 }
 
-output "authority_did_host" {
-  value = length(azurerm_storage_blob.authority_did) > 0 ? azurerm_storage_account.authority_did.primary_web_host : null
+output "dataspace_did_host" {
+  value = length(azurerm_storage_blob.dataspace_did) > 0 ? azurerm_storage_account.dataspace_did.primary_web_host : null
 }
 
 output "gaiax_did_host" {

--- a/docs/developer/decision-records/2022-06-15-registration-service/README.md
+++ b/docs/developer/decision-records/2022-06-15-registration-service/README.md
@@ -84,7 +84,7 @@ In simple scenarios, enrollment could be fast and fully automated. However, in a
 
 #### Overview
 
-A typical EDC deployment caches contract offers from other participants in a federated catalog, so that users can quickly browse and negotiate contracts. To regularly retrieve offers, it regularly contacts the Dataspace Registry (Registration Service) to refresh its list of Dataspace Participants, then obtains contract offers from each participants to refresh its cache.
+A typical EDC deployment caches contract offers from other participants in a federated catalog, so that users can quickly browse and negotiate contracts. To regularly retrieve offers, it regularly contacts the Registration Service to refresh its list of Dataspace Participants, then obtains contract offers from each participants to refresh its cache.
 
 In this flow, the EDC for _Company1_ obtains a list of Dataspace Participants and resolves their IDS endpoints.
 
@@ -96,12 +96,12 @@ Participants are registered as (currently valid) Dataspace Participants
 
 ![list-participants](list-participants.png)
 
-1. The EDC for _Company1_ determines the Dataspace Registry endpoint from the Dataspace DID Document.
-2. The EDC for _Company1_ issues a request to the Dataspace Registry, to list participants.
+1. The EDC for _Company1_ determines the Registration Service endpoint from the Dataspace DID Document.
+2. The EDC for _Company1_ issues a request to the Registration Service, to list participants.
 3. The Registration Service uses the [Distributed authorization sub-flow](../2022-06-16-distributed-authorization/README.md) to authenticate the 
    request...
 4. ... and retrieves Verifiable Presentations from _Company1's_ Identity Hub.
-5. The Registration Service authorizes the request by applying the Registry access policy on the obtained Verifiable Presentations. For example, the caller must be a valid
+5. The Registration Service authorizes the request by applying the access policy on the obtained Verifiable Presentations. For example, the caller must be a valid
    Dataspace Participant.
 6. The Registration Service obtains the list of Dataspace Participant DID URIs from its storage...
 7. ... and returns it synchronously to the caller (_Company1_ EDC).

--- a/docs/developer/decision-records/2022-06-15-registration-service/README.md
+++ b/docs/developer/decision-records/2022-06-15-registration-service/README.md
@@ -84,7 +84,7 @@ In simple scenarios, enrollment could be fast and fully automated. However, in a
 
 #### Overview
 
-A typical EDC deployment caches contract offers from other participants in a federated catalog, so that users can quickly browse and negotiate contracts. To regularly retrieve offers, it regularly contacts the Dataspace Registry to refresh its list of Dataspace Participants, then obtains contract offers from each participants to refresh its cache.
+A typical EDC deployment caches contract offers from other participants in a federated catalog, so that users can quickly browse and negotiate contracts. To regularly retrieve offers, it regularly contacts the Dataspace Registry (Registration Service) to refresh its list of Dataspace Participants, then obtains contract offers from each participants to refresh its cache.
 
 In this flow, the EDC for _Company1_ obtains a list of Dataspace Participants and resolves their IDS endpoints.
 

--- a/docs/developer/decision-records/2022-06-15-registration-service/README.md
+++ b/docs/developer/decision-records/2022-06-15-registration-service/README.md
@@ -79,7 +79,7 @@ In simple scenarios, enrollment could be fast and fully automated. However, in a
 #### Participants
 
 1. _Company1_, a Dataspace Participant with a Dataspace Connector (e.g. EDC application) that wants to discover IDS endpoints (e.g. in order to list contract offers)
-2. _The Dataspace Authority_, which manages the participant registry
+2. _The Dataspace Authority_, which manages Dataspace memberships
 3. _Company2_, _Company3_, etc., Dataspace Participants
 
 #### Overview


### PR DESCRIPTION
## Description

A mix of the names 'registry' and 'registration service' to refer to the 'registration service' is confusing.

Especially as deployers need to first deploy an 'azure container registry', which is unrelated.

Therefore, we want to make sure the names are used consistently.

## Further notes

Renaming `authority_did` in terraform files to `dataspace_did` to not confuse the internal Dataspace DID with the external GAIA-X Authority DID.

linked to #180 