### PR TITLE
Fix CI

### DIFF
--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       API_KEY: ApiKeyDefaultValue
       EDC_HOST: provider
       ASSETS_STORAGE_ACCOUNT: providerassets
-      PARTICIPANT_ID: provider
+      PARTICIPANT_ID: company1
     depends_on:
       consumer-eu:
         condition: service_healthy

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/catalog/CatalogClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/catalog/CatalogClientTest.java
@@ -30,8 +30,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.dataspaceconnector.system.tests.utils.TestUtils.requiredPropOrEnv;
-import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.EU_RESTRICTED_PROVIDER_ASSET_ID;
-import static org.eclipse.dataspaceconnector.system.tests.utils.TransferSimulationUtils.PROVIDER_ASSET_ID;
 
 class CatalogClientTest {
     static final String CONSUMER_EU_CATALOG_URL = requiredPropOrEnv("CONSUMER_EU_CATALOG_URL", "http://localhost:8182/api/federatedcatalog");
@@ -49,7 +47,9 @@ class CatalogClientTest {
         await().atMost(2, MINUTES).untilAsserted(() -> {
             var nodes = getNodesFromCatalog(CONSUMER_US_CATALOG_URL);
             assertThat(nodes).satisfiesExactly(
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).isEqualTo(PROVIDER_ASSET_ID));
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"));
         });
     }
 
@@ -58,8 +58,12 @@ class CatalogClientTest {
         await().atMost(2, MINUTES).untilAsserted(() -> {
             var nodes = getNodesFromCatalog(CONSUMER_EU_CATALOG_URL);
             assertThat(nodes).satisfiesExactlyInAnyOrder(
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).isEqualTo(PROVIDER_ASSET_ID),
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).isEqualTo(EU_RESTRICTED_PROVIDER_ASSET_ID));
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document-2_"),
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document-2_"),
+                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document-2_"));
         });
     }
 

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/catalog/CatalogClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/catalog/CatalogClientTest.java
@@ -34,6 +34,8 @@ import static org.eclipse.dataspaceconnector.system.tests.utils.TestUtils.requir
 class CatalogClientTest {
     static final String CONSUMER_EU_CATALOG_URL = requiredPropOrEnv("CONSUMER_EU_CATALOG_URL", "http://localhost:8182/api/federatedcatalog");
     static final String CONSUMER_US_CATALOG_URL = requiredPropOrEnv("CONSUMER_US_CATALOG_URL", "http://localhost:8183/api/federatedcatalog");
+    static final String NON_RESTRICTED_ASSET_PREFIX = "test-document_";
+    static final String RESTRICTED_ASSET_PREFIX = "test-document-2_";
 
     static TypeManager typeManager = new TypeManager();
 
@@ -46,10 +48,10 @@ class CatalogClientTest {
     void containsOnlyNonRestrictedAsset() {
         await().atMost(2, MINUTES).untilAsserted(() -> {
             var nodes = getNodesFromCatalog(CONSUMER_US_CATALOG_URL);
-            assertThat(nodes).satisfiesExactly(
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"));
+            assertThat(nodes)
+                    .isNotEmpty()
+                    .allSatisfy(
+                        n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith(NON_RESTRICTED_ASSET_PREFIX));
         });
     }
 
@@ -57,13 +59,13 @@ class CatalogClientTest {
     void containsAllAssets() {
         await().atMost(2, MINUTES).untilAsserted(() -> {
             var nodes = getNodesFromCatalog(CONSUMER_EU_CATALOG_URL);
-            assertThat(nodes).satisfiesExactlyInAnyOrder(
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document_"),
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document-2_"),
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document-2_"),
-                    n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString().startsWith("test-document-2_"));
+            assertThat(nodes)
+                    .isNotEmpty()
+                    .allSatisfy(
+                        n -> assertThat(n.getAsset().getProperty(Asset.PROPERTY_ID)).asString()
+                                .satisfiesAnyOf(
+                                        s -> assertThat(s).startsWith(NON_RESTRICTED_ASSET_PREFIX),
+                                        s -> assertThat(s).startsWith(RESTRICTED_ASSET_PREFIX)));
         });
     }
 

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
@@ -50,8 +50,8 @@ public abstract class TransferSimulationUtils {
 
     public static final String DESCRIPTION = "[Contract negotiation and file transfer]";
 
-    public static final String PROVIDER_ASSET_ID = "test-document_provider";
-    public static final String EU_RESTRICTED_PROVIDER_ASSET_ID = "test-document-2_provider";
+    public static final String PROVIDER_ASSET_ID = "test-document_company1";
+    public static final String EU_RESTRICTED_PROVIDER_ASSET_ID = "test-document-2_company1";
     public static final String PROVIDER_ASSET_FILE = "text-document.txt";
 
     public static final String TRANSFER_SUCCESSFUL = "Transfer successful";

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/system/tests/utils/TransferSimulationUtils.java
@@ -219,7 +219,7 @@ public abstract class TransferSimulationUtils {
     private static String loadContractAgreement(String providerUrl) {
         var policy = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
-                        .target("test-document_provider")
+                        .target(PROVIDER_ASSET_ID)
                         .action(Action.Builder.newInstance().type("USE").build())
                         .build())
                 .type(PolicyType.SET)


### PR DESCRIPTION
## What this PR changes/adds

This PR introduces minimal changes to fix the broken cloud CI pipeline on main (see failed run https://github.com/agera-edc/MinimumViableDataspace/runs/7647575335).

Test assets were renamed in https://github.com/eclipse-dataspaceconnector/MinimumViableDataspace/pull/36 but cloud tests were still using the wrong asset naming. This PR does the following fixes:
- Rename provider test asset id to match the cloud naming (test-document_company1)
- Relaxes assertions in `CatalogClientTest` to check only for catalog items matching the corresponding prefix for restricted VS non-restricted assets.

A follow-up PR will consolidate the local test setup further to match 1-1 the connector naming we have in the cloud (company 1,2,3 VS consumer-eu, consumer-us, provider) as well as the catalog entries.

