### PR TITLE
Add APPLICATIONINSIGHTS for Registration Service to cloud deployment

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -25,6 +25,13 @@ runs:
         path: IdentityHub
         ref: 86025904ee4324edad0cd44070b491045589c2c2
 
+    - name: Checkout EDC Data Dashboard
+      uses: actions/checkout@v2
+      with:
+        repository: eclipse-dataspaceconnector/DataDashboard
+        path: DataDashboard
+        ref: ab1b6fd0870fa5ec8c170915a2b44fae63d576bd
+
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2
       with:

--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -14,9 +14,9 @@ runs:
     - name: Checkout Registration Service
       uses: actions/checkout@v2
       with:
-        repository: eclipse-dataspaceconnector/RegistrationService
+        repository: agera-edc/RegistrationService
         path: RegistrationService
-        ref: 0b39c0b0cb1884af58d829fa8396cfa3cf609117
+        ref: feature/247/247-add-appinsights
 
     - name: Checkout Identity Hub
       uses: actions/checkout@v2

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -57,11 +57,12 @@ jobs:
           sudo curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
 
-      - name: 'Run MVD docker-compose'
-        run: docker-compose -f system-tests/docker-compose.yml up --build --wait
+      - name: 'Run MVD docker-compose (incl. MVD UI)'
+        run: docker-compose --profile ui -f system-tests/docker-compose.yml up --build --wait
         timeout-minutes: 10
         env:
           REGISTRATION_SERVICE_LAUNCHER_PATH: ${{ runner.temp }}/RegistrationService/launcher
+          MVD_UI_PATH: DataDashboard
 
       - name: 'Unit and system tests'
         run: ./gradlew test
@@ -75,6 +76,7 @@ jobs:
         if: always()
         env:
           REGISTRATION_SERVICE_LAUNCHER_PATH: ${{ runner.temp }}/RegistrationService/launcher
+          MVD_UI_PATH: DataDashboard
 
       - name: "Publish Gatling report"
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -114,12 +114,8 @@ jobs:
     env:
       ACR_NAME: ${{ secrets.ACR_NAME }}
     steps:
-      - name: Checkout DataDashboard
-        uses: actions/checkout@v2
-        with:
-          repository: eclipse-dataspaceconnector/DataDashboard
-          ref: ab1b6fd0870fa5ec8c170915a2b44fae63d576bd
-
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/gradle-setup
       - name: 'Az CLI login'
         uses: azure/login@v1
         with:
@@ -132,7 +128,7 @@ jobs:
 
       # Build Docker runtime image remotely on ACR & push it to the registry.
       - name: 'Build image'
-        run: az acr build --registry $ACR_NAME --image mvd/data-dashboard:${{ env.RESOURCES_PREFIX }} .
+        run: az acr build --registry $ACR_NAME --image mvd/data-dashboard:${{ env.RESOURCES_PREFIX }} DataDashboard
 
   # Deploy shared dataspace components.
   Deploy-Dataspace:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,114 @@ Follow these steps to delete a dataspace instance and free up the corresponding 
 - Provide the resources prefix that you used when you deployed your DataSpace.
 - Click on `Run workflow` to trigger to destroy your MinimumViableDataspace DataSpace.
 
-## Local development setup
+## Local Development Setup
 
-Please follow the instructions in [this document](system-tests/README.md) to setup a local MVD environment for development purposes.
+The MVD backend and MVD UI (Data Dashboard) can be run locally for testing and development.
+
+1. Check out the
+   repository [eclipse-dataspaceconnector/DataDashboard](https://github.com/eclipse-dataspaceconnector/DataDashboard) or
+   your corresponding fork.
+2. Set the environment variable `MVD_UI_PATH` to the path of the DataDashboard repository. (See example below.)
+3. Use the instructions in section `Publish/Build Tasks` [system-tests/README.md](system-tests/README.md) to set up a
+   local MVD environment with the exception to use the profile `ui`. (See example below.)
+   - In order to verify your local environment works properly, also follow section `Local Test Execution`
+     in `system-tests/README.md` .
+
+> Using the profile `ui` will create three MVD UIs (Data Dashboards) for each EDC participant in addition to the
+> services described in [system-tests/README.md](system-tests/README.md).
+
+Bash:
+
+```bash
+export MVD_UI_PATH="/path/to/mvd-datadashboard"
+docker-compose --profile ui -f system-tests/docker-compose.yml up --build
+```
+
+PowerShell:
+
+```powershell
+$Env:MVD_UI_PATH="/path/to/mvd-datadashboard"
+docker-compose --profile ui -f system-tests/docker-compose.yml up --build
+```
+
+> In Windows Docker Compose expects the path to use forward slashes instead of backslashes.
+
+The profile `ui` creates three Data Dashboards each connected to an EDC participant. The respective `app.config.json`
+files can be found in the respective directories:
+
+- `resources/appconfig/company1/app.config.json`
+- `resources/appconfig/company2/app.config.json`
+- `resources/appconfig/company3/app.config.json`
+
+That's it to run the local development environment. The following section `Run A Standard Scenario Locally` describes a
+standard scenario which can be optionally used with the local development environment.
+
+> Tip: The console output from the services spun up by Docker compose can be noisy. To decrease the output from the
+> services on the console set `EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS` to a higher value, e.g. 60, for each EDC
+> participant in `system-tests/docker-compose.yml`.
+
+### Run A Standard Scenario Locally
+
+Prerequisite: create a test document manually:
+
+- Connect to the **local** blob storage account (provided by Azurite) of company1.
+  - Storage account name: `company1assets`, storage account key: `key1`.
+  - [Microsoft Azure Storage Explorer](https://azure.microsoft.com/features/storage-explorer/) can be used to connect to the local
+    storage account on `localhost:10000`.
+- Create a container named `src-container`. (Container name is defined for Postman request `Publish Master Data`
+  in `deployment/data/MVD.postman_collection.json`)
+- Copy `deployment/terraform/participant/sample-data/text-document.txt` into the newly created container.
+  - N.B.: it does not have to be this exact file as long you create a file which has the name `text-document.txt`.
+
+All this can also be done using Azure CLI with the following lines from the root of the MVD repository:
+
+Bash:
+
+```bash
+conn_str="DefaultEndpointsProtocol=http;AccountName=company1assets;AccountKey=key1;BlobEndpoint=http://127.0.0.1:10000/company1assets;"
+az storage container create --name src-container --connection-string $conn_str
+az storage blob upload -f ./deployment/terraform/participant/sample-data/text-document.txt --container-name src-container --name text-document.txt --connection-string $conn_str
+```
+
+PowerShell:
+
+```powershell
+$conn_str="DefaultEndpointsProtocol=http;AccountName=company1assets;AccountKey=key1;BlobEndpoint=http://127.0.0.1:10000/company1assets;"
+az storage container create --name src-container --connection-string $conn_str
+az storage blob upload -f .\deployment\terraform\participant\sample-data\text-document.txt --container-name src-container --name text-document.txt --connection-string $conn_str
+```
+
+This should result in a similar output as follows. Via the Microsoft Azure Storage Explorer it would be possible to
+review the new container and the uploaded blob.
+
+```bash
+{
+  "created": true
+}
+
+Finished[#############################################################]  100.0000%
+{
+  "etag": "\"0x1CC7CAB96842160\"",
+  "lastModified": "2022-08-08T15:14:01+00:00"
+}
+```
+
+The following steps initiate and complete a file transfer with the provided test document.
+
+- Open the website of company1 (e.g. <http://localhost:7080>) and verify the existence of two assets in the
+  section `Assets`.
+- Open the website of the company2 (e.g. <http://localhost:7081>) and verify six existing assets from all participants in
+  the `Catalog Browser`.
+  - In the `Catalog Browser` click `Negotiate` for the asset `test-document_company1`.
+    - There should be a message `Contract Negotiation complete! Show me!` in less than a minute.
+- From the previous message click `Show me!`. If you missed it, switch manually to the section `Contracts`.
+  - There should be a new contract. Click `Transfer` to initiate the transfer process.
+  - A dialog should open. Here, select as destination `AzureStorage` and click `Start transfer`.
+  - There should be a message `Transfer [id] complete! Show me!` in less than a minute. (Where `id` is a UUID.)
+- To verify the successful transfer the Storage Explorer can be used to look into the storage account of `company2`.
+  - Storage account name and key is set in `system-tests/docker-compose.yml` for the service `azurite`. Default name
+    is `company2assets`, key is `key2`.
+  - There should be new container in the storage account containing two files `.complete` and `test-document.txt`.
 
 ## Contributing
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,9 +6,6 @@ plugins {
 
 allprojects {
     apply(plugin = "java")
-    if (System.getenv("JACOCO") == "true") {
-        apply(plugin = "jacoco")
-    }
 
     repositories {
         mavenCentral()

--- a/deployment/terraform/dataspace/main.tf
+++ b/deployment/terraform/dataspace/main.tf
@@ -85,10 +85,15 @@ resource "azurerm_container_group" "registration-service" {
     }
 
     environment_variables = {
-      EDC_CONNECTOR_NAME      = local.connector_name
-      JWT_AUDIENCE            = local.registration_service_url
-      WEB_HTTP_AUTHORITY_PORT = local.registration_service_port
-      WEB_HTTP_AUTHORITY_PATH = local.registration_service_path_prefix
+      EDC_CONNECTOR_NAME            = local.connector_name
+      JWT_AUDIENCE                  = local.registration_service_url
+      WEB_HTTP_AUTHORITY_PORT       = local.registration_service_port
+      WEB_HTTP_AUTHORITY_PATH       = local.registration_service_path_prefix
+      APPLICATIONINSIGHTS_ROLE_NAME = local.connector_name
+    }
+
+    secure_environment_variables = {
+      APPLICATIONINSIGHTS_CONNECTION_STRING = azurerm_application_insights.dataspace.connection_string
     }
 
     liveness_probe {

--- a/deployment/terraform/participant/main.tf
+++ b/deployment/terraform/participant/main.tf
@@ -272,6 +272,11 @@ resource "azurerm_storage_blob" "did" {
         "id" : "#identity-hub-url",
         "type" : "IdentityHub",
         "serviceEndpoint" : "http://${azurerm_container_group.edc.fqdn}:${local.edc_default_port}/api/identity-hub"
+      },
+      {
+        "id" : "#ids-url",
+        "type" : "IDSMessaging",
+        "serviceEndpoint" : "http://${urlencode(azurerm_container_group.edc.fqdn)}:${local.edc_ids_port}"
       }
     ],
     "verificationMethod" = [

--- a/extensions/policies/src/main/java/org/eclipse/dataspaceconnector/mvd/SeedPoliciesExtension.java
+++ b/extensions/policies/src/main/java/org/eclipse/dataspaceconnector/mvd/SeedPoliciesExtension.java
@@ -68,5 +68,4 @@ public class SeedPoliciesExtension implements ServiceExtension {
 
         policyEngine.registerFunction(ALL_SCOPES, Permission.class, ABS_SPATIAL_POSITION, new RegionConstraintFunction(typeManager.getMapper(), monitor));
     }
-
 }

--- a/extensions/refresh-catalog/build.gradle.kts
+++ b/extensions/refresh-catalog/build.gradle.kts
@@ -14,11 +14,15 @@ val faker: String by project
 dependencies {
     implementation("${edcGroup}:common-util:${edcVersion}")
     implementation("${edcGroup}:federated-catalog-spi:${edcVersion}")
+    implementation("${edcGroup}:identity-did-core:${edcVersion}")
+    implementation("${edcGroup}:identity-did-web:${edcVersion}")
+    implementation("${edcGroup}:ids-spi:${edcVersion}")
     implementation("${registrationServiceGroup}:registration-service-client:${registrationServiceVersion}")
 
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation("com.github.javafaker:javafaker:${faker}")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/FederatedCacheNodeResolver.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/FederatedCacheNodeResolver.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.mvd;
+
+import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNode;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.dataspaceconnector.ids.spi.Protocols;
+import org.eclipse.dataspaceconnector.registration.client.models.Participant;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+/**
+ * Resolves the {@link FederatedCacheNode}s from the Participant's Did Document.
+ */
+class FederatedCacheNodeResolver {
+
+    public static final String IDS_MESSAGING = "IDSMessaging";
+    public static final List<String> SUPPORTED_PROTOCOLS = List.of(Protocols.IDS_MULTIPART);
+
+    private final DidResolverRegistry resolver;
+    private final Monitor monitor;
+
+    FederatedCacheNodeResolver(DidResolverRegistry resolver, Monitor monitor) {
+        this.resolver = resolver;
+        this.monitor = monitor;
+    }
+
+    public Result<FederatedCacheNode> toFederatedCacheNode(Participant participant) {
+        var did = participant.getDid();
+        monitor.debug(format("Resolving Did Document for did %s.", did));
+        var didDocument = resolver.resolve(did);
+        if (didDocument.failed()) {
+            monitor.severe(() -> format("Failed to resolve DID Document for %s. %s", did, didDocument.getFailureDetail()));
+            return Result.failure("Can't resolve Did Document for participant: " + did);
+        }
+        return getUrl(didDocument.getContent())
+                .map(url -> Result.success(new FederatedCacheNode(didDocument.getContent().getId(), url, SUPPORTED_PROTOCOLS)))
+                .orElseGet(() -> Result.failure(format("Can't resolve Did Document for participant: %s", did)));
+    }
+
+    private Optional<String> getUrl(DidDocument didDocument) {
+        return didDocument
+                .getService().stream()
+                .filter(service -> service.getType().equals(IDS_MESSAGING))
+                .map(Service::getServiceEndpoint)
+                .findFirst();
+    }
+}

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/FederatedCacheNodeResolver.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/FederatedCacheNodeResolver.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.mvd;
+
+import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNode;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.dataspaceconnector.ids.spi.Protocols;
+import org.eclipse.dataspaceconnector.registration.client.models.ParticipantDto;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+/**
+ * Resolves the {@link FederatedCacheNode}s from the Participant's Did Document.
+ */
+class FederatedCacheNodeResolver {
+
+    public static final String IDS_MESSAGING = "IDSMessaging";
+    public static final List<String> SUPPORTED_PROTOCOLS = List.of(Protocols.IDS_MULTIPART);
+
+    private final DidResolverRegistry resolver;
+    private final Monitor monitor;
+
+    FederatedCacheNodeResolver(DidResolverRegistry resolver, Monitor monitor) {
+        this.resolver = resolver;
+        this.monitor = monitor;
+    }
+
+    public Result<FederatedCacheNode> toFederatedCacheNode(ParticipantDto participant) {
+        var did = participant.getDid();
+        monitor.debug(format("Resolving Did Document for did %s.", did));
+        var didDocument = resolver.resolve(did);
+        if (didDocument.failed()) {
+            monitor.severe(() -> format("Failed to resolve DID Document for %s. %s", did, didDocument.getFailureDetail()));
+            return Result.failure("Can't resolve Did Document for participant: " + did);
+        }
+        return getUrl(didDocument.getContent())
+                .map(url -> Result.success(new FederatedCacheNode(didDocument.getContent().getId(), url, SUPPORTED_PROTOCOLS)))
+                .orElseGet(() -> Result.failure(format("Can't resolve Did Document for participant: %s", did)));
+    }
+
+    private Optional<String> getUrl(DidDocument didDocument) {
+        return didDocument
+                .getService().stream()
+                .filter(service -> service.getType().equals(IDS_MESSAGING))
+                .map(Service::getServiceEndpoint)
+                .findFirst();
+    }
+}

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectory.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectory.java
@@ -17,7 +17,7 @@ package org.eclipse.dataspaceconnector.mvd;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNode;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNodeDirectory;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
-import org.eclipse.dataspaceconnector.registration.client.models.Participant;
+import org.eclipse.dataspaceconnector.registration.client.models.ParticipantDto;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,7 +43,7 @@ public class RegistrationServiceNodeDirectory implements FederatedCacheNodeDirec
         return apiClient.listParticipants().stream().map(this::toFederatedCacheNode).collect(Collectors.toList());
     }
 
-    private FederatedCacheNode toFederatedCacheNode(Participant participant) {
+    private FederatedCacheNode toFederatedCacheNode(ParticipantDto participant) {
         return new FederatedCacheNode(participant.getName(), participant.getUrl(), participant.getSupportedProtocols());
     }
 

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectory.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectory.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNode;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNodeDirectory;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
 import org.eclipse.dataspaceconnector.registration.client.models.Participant;
+import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,23 +29,26 @@ import java.util.stream.Collectors;
 public class RegistrationServiceNodeDirectory implements FederatedCacheNodeDirectory {
 
     private final RegistryApi apiClient;
+    private final FederatedCacheNodeResolver resolver;
 
     /**
      * Constructs {@link RegistrationServiceNodeDirectory}
      *
      * @param apiClient RegistrationService API client.
+     * @param resolver gets {@link FederatedCacheNode} from {@link Participant}
      */
-    public RegistrationServiceNodeDirectory(RegistryApi apiClient) {
+    public RegistrationServiceNodeDirectory(RegistryApi apiClient, FederatedCacheNodeResolver resolver) {
         this.apiClient = apiClient;
+        this.resolver = resolver;
     }
 
     @Override
     public List<FederatedCacheNode> getAll() {
-        return apiClient.listParticipants().stream().map(this::toFederatedCacheNode).collect(Collectors.toList());
-    }
-
-    private FederatedCacheNode toFederatedCacheNode(Participant participant) {
-        return new FederatedCacheNode(participant.getName(), participant.getUrl(), participant.getSupportedProtocols());
+        return apiClient.listParticipants().stream()
+                .map(resolver::toFederatedCacheNode)
+                .filter(AbstractResult::succeeded)
+                .map(AbstractResult::getContent)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectory.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectory.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNode;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNodeDirectory;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
 import org.eclipse.dataspaceconnector.registration.client.models.ParticipantDto;
+import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,23 +29,26 @@ import java.util.stream.Collectors;
 public class RegistrationServiceNodeDirectory implements FederatedCacheNodeDirectory {
 
     private final RegistryApi apiClient;
+    private final FederatedCacheNodeResolver resolver;
 
     /**
      * Constructs {@link RegistrationServiceNodeDirectory}
      *
      * @param apiClient RegistrationService API client.
+     * @param resolver gets {@link FederatedCacheNode} from {@link ParticipantDto}
      */
-    public RegistrationServiceNodeDirectory(RegistryApi apiClient) {
+    public RegistrationServiceNodeDirectory(RegistryApi apiClient, FederatedCacheNodeResolver resolver) {
         this.apiClient = apiClient;
+        this.resolver = resolver;
     }
 
     @Override
     public List<FederatedCacheNode> getAll() {
-        return apiClient.listParticipants().stream().map(this::toFederatedCacheNode).collect(Collectors.toList());
-    }
-
-    private FederatedCacheNode toFederatedCacheNode(ParticipantDto participant) {
-        return new FederatedCacheNode(participant.getName(), participant.getUrl(), participant.getSupportedProtocols());
+        return apiClient.listParticipants().stream()
+                .map(resolver::toFederatedCacheNode)
+                .filter(AbstractResult::succeeded)
+                .map(AbstractResult::getContent)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectoryExtension.java
+++ b/extensions/refresh-catalog/src/main/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectoryExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.mvd;
 
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNodeDirectory;
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.dataspaceconnector.registration.client.ApiClientFactory;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
 import org.eclipse.dataspaceconnector.spi.EdcSetting;
@@ -44,6 +45,9 @@ public class RegistrationServiceNodeDirectoryExtension implements ServiceExtensi
     @Inject
     private IdentityService identityService;
 
+    @Inject
+    private DidResolverRegistry didResolverRegistry;
+
     private String registrationServiceApiUrl;
 
     @Override
@@ -56,7 +60,8 @@ public class RegistrationServiceNodeDirectoryExtension implements ServiceExtensi
     public FederatedCacheNodeDirectory federatedCacheNodeDirectory() {
         var apiClient = ApiClientFactory.createApiClient(registrationServiceApiUrl, identityService::obtainClientCredentials);
         var registryApiClient = new RegistryApi(apiClient);
-        return new RegistrationServiceNodeDirectory(registryApiClient);
+        var resolver = new FederatedCacheNodeResolver(didResolverRegistry, monitor);
+        return new RegistrationServiceNodeDirectory(registryApiClient, resolver);
     }
 }
 

--- a/extensions/refresh-catalog/src/test/java/org/eclipse/dataspaceconnector/mvd/FederatedCacheNodeResolverTest.java
+++ b/extensions/refresh-catalog/src/test/java/org/eclipse/dataspaceconnector/mvd/FederatedCacheNodeResolverTest.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.mvd;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.dataspaceconnector.registration.client.models.Participant;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.List.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FederatedCacheNodeResolverTest {
+
+    static final String IDS_MESSAGING = "IDSMessaging";
+    static final Faker FAKER = Faker.instance();
+    public static final String SUPPORTED_PROTOCOL = "ids-multipart";
+    static String did = "did:web:" + FAKER.internet().domainName();
+    static String idsUrl = FAKER.internet().url();
+
+    FederatedCacheNodeResolver resolver;
+    DidResolverRegistry didResolver = mock(DidResolverRegistry.class);
+    Monitor monitor = mock(Monitor.class);
+
+    @ParameterizedTest
+    @MethodSource("argumentsStreamSuccess")
+    void getNode_success(List<Service> services) {
+        when(didResolver.resolve(did)).thenReturn(Result.success(getDidDocument(services)));
+
+        resolver = new FederatedCacheNodeResolver(didResolver, monitor);
+
+        var result = resolver.toFederatedCacheNode(new Participant().did(did));
+
+        assertThat(result.succeeded()).isTrue();
+        var node = result.getContent();
+        assertThat(node.getName()).isEqualTo(did);
+        assertThat(node.getTargetUrl()).isEqualTo(idsUrl);
+        assertThat(node.getSupportedProtocols()).containsExactly(SUPPORTED_PROTOCOL);
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsStreamFailure")
+    void getNode_failure(Result result) {
+        when(didResolver.resolve(did)).thenReturn(result);
+
+        resolver = new FederatedCacheNodeResolver(didResolver, monitor);
+
+        var nodeResult = resolver.toFederatedCacheNode(new Participant().did(did));
+
+        assertThat(nodeResult.failed()).isTrue();
+    }
+
+    @Test
+    void getNode_success_twoIdsMessagingServices() {
+        String url1 = FAKER.internet().url();
+        String url2 = FAKER.internet().url();
+        when(didResolver.resolve(did)).thenReturn(Result.success(getDidDocument(of(idsMessagingService(url2), idsMessagingService(url1)))));
+
+        resolver = new FederatedCacheNodeResolver(didResolver, monitor);
+
+        var result = resolver.toFederatedCacheNode(new Participant().did(did));
+
+        assertThat(result.succeeded()).isTrue();
+        var node = result.getContent();
+        assertThat(node.getName()).isEqualTo(did);
+        assertThat(node.getTargetUrl()).isIn(url1, url2);
+        assertThat(node.getSupportedProtocols()).containsExactly(SUPPORTED_PROTOCOL);
+    }
+
+    @NotNull
+    private static DidDocument getDidDocument(List<Service> services) {
+        return DidDocument.Builder.newInstance().id(did).service(services).build();
+    }
+
+    private static Stream<Arguments> argumentsStreamSuccess() {
+        return Stream.of(
+                arguments(of(idsMessagingService(idsUrl))),
+                arguments(of(idsMessagingService(idsUrl), idsMessagingService(idsUrl))),
+                arguments(of(idsMessagingService(idsUrl), fakeService()))
+        );
+    }
+
+    private static Stream<Arguments> argumentsStreamFailure() {
+        return Stream.of(
+                arguments(Result.failure("failure")),
+                arguments(Result.success(getDidDocument(of(fakeService(), fakeService())))),
+                arguments(Result.success(getDidDocument(of(service(idsUrl, FAKER.lorem().word()))))),
+                arguments(Result.success(getDidDocument(of())))
+        );
+    }
+
+    @NotNull
+    private static Service fakeService() {
+        return service(FAKER.internet().url(), FAKER.lorem().word());
+    }
+
+    @NotNull
+    private static Service idsMessagingService(String url) {
+        return service(url, IDS_MESSAGING);
+    }
+
+    @NotNull
+    private static Service service(String url, String type) {
+        return new Service(FAKER.lorem().word(), type, url);
+    }
+
+}

--- a/extensions/refresh-catalog/src/test/java/org/eclipse/dataspaceconnector/mvd/FederatedCacheNodeResolverTest.java
+++ b/extensions/refresh-catalog/src/test/java/org/eclipse/dataspaceconnector/mvd/FederatedCacheNodeResolverTest.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.mvd;
+
+import com.github.javafaker.Faker;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.dataspaceconnector.registration.client.models.ParticipantDto;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.List.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FederatedCacheNodeResolverTest {
+
+    static final String IDS_MESSAGING = "IDSMessaging";
+    static final Faker FAKER = Faker.instance();
+    public static final String SUPPORTED_PROTOCOL = "ids-multipart";
+    static String did = "did:web:" + FAKER.internet().domainName();
+    static String idsUrl = FAKER.internet().url();
+
+    FederatedCacheNodeResolver resolver;
+    DidResolverRegistry didResolver = mock(DidResolverRegistry.class);
+    Monitor monitor = mock(Monitor.class);
+
+    @ParameterizedTest
+    @MethodSource("argumentsStreamSuccess")
+    void getNode_success(List<Service> services) {
+        when(didResolver.resolve(did)).thenReturn(Result.success(getDidDocument(services)));
+
+        resolver = new FederatedCacheNodeResolver(didResolver, monitor);
+
+        var result = resolver.toFederatedCacheNode(new ParticipantDto().did(did));
+
+        assertThat(result.succeeded()).isTrue();
+        var node = result.getContent();
+        assertThat(node.getName()).isEqualTo(did);
+        assertThat(node.getTargetUrl()).isEqualTo(idsUrl);
+        assertThat(node.getSupportedProtocols()).containsExactly(SUPPORTED_PROTOCOL);
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsStreamFailure")
+    void getNode_failure(Result result) {
+        when(didResolver.resolve(did)).thenReturn(result);
+
+        resolver = new FederatedCacheNodeResolver(didResolver, monitor);
+
+        var nodeResult = resolver.toFederatedCacheNode(new ParticipantDto().did(did));
+
+        assertThat(nodeResult.failed()).isTrue();
+    }
+
+    @Test
+    void getNode_success_twoIdsMessagingServices() {
+        String url1 = FAKER.internet().url();
+        String url2 = FAKER.internet().url();
+        when(didResolver.resolve(did)).thenReturn(Result.success(getDidDocument(of(idsMessagingService(url2), idsMessagingService(url1)))));
+
+        resolver = new FederatedCacheNodeResolver(didResolver, monitor);
+
+        var result = resolver.toFederatedCacheNode(new ParticipantDto().did(did));
+
+        assertThat(result.succeeded()).isTrue();
+        var node = result.getContent();
+        assertThat(node.getName()).isEqualTo(did);
+        assertThat(node.getTargetUrl()).isIn(url1, url2);
+        assertThat(node.getSupportedProtocols()).containsExactly(SUPPORTED_PROTOCOL);
+    }
+
+    @NotNull
+    private static DidDocument getDidDocument(List<Service> services) {
+        return DidDocument.Builder.newInstance().id(did).service(services).build();
+    }
+
+    private static Stream<Arguments> argumentsStreamSuccess() {
+        return Stream.of(
+                arguments(of(idsMessagingService(idsUrl))),
+                arguments(of(idsMessagingService(idsUrl), idsMessagingService(idsUrl))),
+                arguments(of(idsMessagingService(idsUrl), fakeService()))
+        );
+    }
+
+    private static Stream<Arguments> argumentsStreamFailure() {
+        return Stream.of(
+                arguments(Result.failure("failure")),
+                arguments(Result.success(getDidDocument(of(fakeService(), fakeService())))),
+                arguments(Result.success(getDidDocument(of(service(idsUrl, FAKER.lorem().word()))))),
+                arguments(Result.success(getDidDocument(of())))
+        );
+    }
+
+    @NotNull
+    private static Service fakeService() {
+        return service(FAKER.internet().url(), FAKER.lorem().word());
+    }
+
+    @NotNull
+    private static Service idsMessagingService(String url) {
+        return service(url, IDS_MESSAGING);
+    }
+
+    @NotNull
+    private static Service service(String url, String type) {
+        return new Service(FAKER.lorem().word(), type, url);
+    }
+
+}

--- a/extensions/refresh-catalog/src/test/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectoryTest.java
+++ b/extensions/refresh-catalog/src/test/java/org/eclipse/dataspaceconnector/mvd/RegistrationServiceNodeDirectoryTest.java
@@ -18,55 +18,76 @@ import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.catalog.spi.FederatedCacheNode;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
 import org.eclipse.dataspaceconnector.registration.client.models.Participant;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class RegistrationServiceNodeDirectoryTest {
 
     static Faker faker = new Faker();
 
-    private final RegistryApi registryApi = Mockito.mock(RegistryApi.class);
+    private final RegistryApi registryApi = mock(RegistryApi.class);
+    private final FederatedCacheNodeResolver resolver = mock(FederatedCacheNodeResolver.class);
 
     @Test
     void getAll_emptyList() {
-        var service = new RegistrationServiceNodeDirectory(registryApi);
+        var service = new RegistrationServiceNodeDirectory(registryApi, resolver);
 
         when(registryApi.listParticipants()).thenReturn(List.of());
 
-        List<FederatedCacheNode> cacheNodes = service.getAll();
+        var cacheNodes = service.getAll();
         assertThat(cacheNodes).isEmpty();
     }
 
     @Test
     void getAll() {
-        var service = new RegistrationServiceNodeDirectory(registryApi);
+        var service = new RegistrationServiceNodeDirectory(registryApi, resolver);
 
         var company1 = getParticipant();
         var company2 = getParticipant();
+        var node1 = node();
+        var node2 = node();
         when(registryApi.listParticipants()).thenReturn(List.of(company1, company2));
+        when(resolver.toFederatedCacheNode(company1)).thenReturn(Result.success(node1));
+        when(resolver.toFederatedCacheNode(company2)).thenReturn(Result.success(node2));
 
-        List<FederatedCacheNode> cacheNodes = service.getAll();
+        var cacheNodes = service.getAll();
         assertThat(cacheNodes)
                 .usingRecursiveFieldByFieldElementComparator()
-                .containsExactly(mapToNode(company1), mapToNode(company2));
+                .containsExactly(node1, node2);
     }
 
-    private FederatedCacheNode mapToNode(Participant participant) {
-        return new FederatedCacheNode(participant.getName(), participant.getUrl(), participant.getSupportedProtocols());
+    @Test
+    void getAll_failureResolvingDid() {
+        var service = new RegistrationServiceNodeDirectory(registryApi, resolver);
+
+        var company1 = getParticipant();
+        var company2 = getParticipant();
+        var node1 = node();
+        when(registryApi.listParticipants()).thenReturn(List.of(company1, company2));
+        when(resolver.toFederatedCacheNode(company1)).thenReturn(Result.success(node1));
+        when(resolver.toFederatedCacheNode(company2)).thenReturn(Result.failure("failure"));
+
+        var cacheNodes = service.getAll();
+        assertThat(cacheNodes)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(node1);
+    }
+
+    private FederatedCacheNode node() {
+        return new FederatedCacheNode(faker.lorem().word(), faker.internet().url(), List.of("ids-multipart"));
     }
 
     @NotNull
     private Participant getParticipant() {
         var participant = new Participant();
-        participant.setName(faker.lorem().word());
-        participant.setUrl(faker.internet().url());
-        participant.setSupportedProtocols(List.of(faker.lorem().word(), faker.lorem().word()));
+        participant.setDid(String.format("did:web:%s", faker.internet().domainName()));
         return participant;
     }
 }

--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -15,14 +15,17 @@ System tests are run both in local deployment (using docker compose) and in the 
 > are __not__ published to any central artifact repository yet, so in local development we have to use locally
 > published dependencies.
 >
->In order to use the correct version of each repo required by the `MVD`, you need to look in [action.yml](./.github/actions/../../../.github/actions/gradle-setup/action.yml) for the hashes of the versions of the `EDC`, `Identity Hub` and the `Registration Service` that are being used by the `MVD`.
+> In order to use the correct version of each repo required by the `MVD`, you need to look
+> in [action.yml](../.github/actions/gradle-setup/action.yml) for the hashes of the versions of the `EDC`, `Identity Hub`
+> and the `Registration Service` that are being used by the `MVD`.
 >
 > For Example for the dependency repositories:
 > - `Registration Service`
 > - `Identity Hub`
 > - `EDC`
 >
->  the hash (which is subject to change from the values presented here as an example) can be found in the _Checkout_ steps  (in the `ref` property) of [action.yml](./.github/actions/gradle-setup/action.yml):
+> the hash (which is subject to change from the values presented here as an example) can be found in the _Checkout_
+> steps (in the `ref` property) of `action.yml`:
 
 ```yml
     - name: Checkout EDC
@@ -101,7 +104,7 @@ Execute the following command from `Identity Hub` root folder:
 Execute the following command from `Registration Service` root folder:
 
 ```bash
-./gradlew publishToMavenLocal
+./gradlew publishToMavenLocal -P "skip.signing"
 ```
 
 <br />

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
       REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
+      EDC_WEB_REST_CORS_ENABLED: "true"
+      EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
     depends_on:
       - did-server
       - azurite
@@ -51,6 +53,8 @@ services:
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
       REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
+      EDC_WEB_REST_CORS_ENABLED: "true"
+      EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
     depends_on:
       - did-server
       - azurite
@@ -82,6 +86,8 @@ services:
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
       REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
+      EDC_WEB_REST_CORS_ENABLED: "true"
+      EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
     depends_on:
       - did-server
       - azurite
@@ -166,3 +172,45 @@ services:
         condition: service_healthy
       registration-service:
         condition: service_healthy
+
+  # Data Dashboard (MVD UI) for participant company1
+  company1-datadashboard:
+    container_name: company1-datadashboard
+    build:
+      context: ${MVD_UI_PATH}
+    volumes:
+      - ./resources/appconfig/company1:/usr/share/nginx/html/assets/config
+    depends_on:
+      company1:
+        condition: service_healthy
+    ports:
+      - "7080:80"
+    profiles: ["ui"]
+
+      # Data Dashboard (MVD UI) for participant company2
+  company2-datadashboard:
+    container_name: company2-datadashboard
+    build:
+      context: ${MVD_UI_PATH}
+    volumes:
+      - ./resources/appconfig/company2:/usr/share/nginx/html/assets/config
+    depends_on:
+      company2:
+        condition: service_healthy
+    ports:
+      - "7081:80"
+    profiles: ["ui"]
+
+  # Data Dashboard (MVD UI) for participant company3
+  company3-datadashboard:
+    container_name: company3-datadashboard
+    build:
+      context: ${MVD_UI_PATH}
+    volumes:
+      - ./resources/appconfig/company3:/usr/share/nginx/html/assets/config
+    depends_on:
+      company3:
+        condition: service_healthy
+    ports:
+      - "7082:80"
+    profiles: ["ui"]

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -137,7 +137,7 @@ services:
   registration-service:
     container_name: registration-service
     build:
-#e.g. /home/user/RegistrationService/launcher
+      #e.g. /home/user/RegistrationService/launcher
       context: ${REGISTRATION_SERVICE_LAUNCHER_PATH:?"Registration Service launcher path env var required"}
       args:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008"

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
       REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
+      EDC_WEB_REST_CORS_ENABLED: "true"
+      EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
     depends_on:
       - did-server
       - azurite
@@ -51,6 +53,8 @@ services:
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
       REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
+      EDC_WEB_REST_CORS_ENABLED: "true"
+      EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
     depends_on:
       - did-server
       - azurite
@@ -82,6 +86,8 @@ services:
       EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: 5
       EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: 5
       REGISTRATION_SERVICE_API_URL: http://registration-service:8184/authority
+      EDC_WEB_REST_CORS_ENABLED: "true"
+      EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
     depends_on:
       - did-server
       - azurite
@@ -137,7 +143,7 @@ services:
   registration-service:
     container_name: registration-service
     build:
-#e.g. /home/user/RegistrationService/launcher
+      #e.g. /home/user/RegistrationService/launcher
       context: ${REGISTRATION_SERVICE_LAUNCHER_PATH:?"Registration Service launcher path env var required"}
       args:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008"
@@ -166,3 +172,45 @@ services:
         condition: service_healthy
       registration-service:
         condition: service_healthy
+
+  # Data Dashboard (MVD UI) for participant company1
+  company1-datadashboard:
+    container_name: company1-datadashboard
+    build:
+      context: ${MVD_UI_PATH}
+    volumes:
+      - ./resources/appconfig/company1:/usr/share/nginx/html/assets/config
+    depends_on:
+      company1:
+        condition: service_healthy
+    ports:
+      - "7080:80"
+    profiles: ["ui"]
+
+      # Data Dashboard (MVD UI) for participant company2
+  company2-datadashboard:
+    container_name: company2-datadashboard
+    build:
+      context: ${MVD_UI_PATH}
+    volumes:
+      - ./resources/appconfig/company2:/usr/share/nginx/html/assets/config
+    depends_on:
+      company2:
+        condition: service_healthy
+    ports:
+      - "7081:80"
+    profiles: ["ui"]
+
+  # Data Dashboard (MVD UI) for participant company3
+  company3-datadashboard:
+    container_name: company3-datadashboard
+    build:
+      context: ${MVD_UI_PATH}
+    volumes:
+      - ./resources/appconfig/company3:/usr/share/nginx/html/assets/config
+    depends_on:
+      company3:
+        condition: service_healthy
+    ports:
+      - "7082:80"
+    profiles: ["ui"]

--- a/system-tests/resources/appconfig/company1/app.config.json
+++ b/system-tests/resources/appconfig/company1/app.config.json
@@ -1,0 +1,8 @@
+{
+  "apiKey": "ApiKeyDefaultValue",
+  "catalogUrl": "http://localhost:8181/api/federatedcatalog",
+  "dataManagementApiUrl": "http://localhost:9191/api/v1/data",
+  "storageAccount": "company1assets",
+  "storageExplorerLinkTemplate": "storageexplorer://v=1",
+  "theme": "theme-1"
+}

--- a/system-tests/resources/appconfig/company2/app.config.json
+++ b/system-tests/resources/appconfig/company2/app.config.json
@@ -1,0 +1,8 @@
+{
+  "apiKey": "ApiKeyDefaultValue",
+  "catalogUrl": "http://localhost:8182/api/federatedcatalog",
+  "dataManagementApiUrl": "http://localhost:9192/api/v1/data",
+  "storageAccount": "company2assets",
+  "storageExplorerLinkTemplate": "storageexplorer://v=1",
+  "theme": "theme-2"
+}

--- a/system-tests/resources/appconfig/company3/app.config.json
+++ b/system-tests/resources/appconfig/company3/app.config.json
@@ -1,0 +1,8 @@
+{
+  "apiKey": "ApiKeyDefaultValue",
+  "catalogUrl": "http://localhost:8183/api/federatedcatalog",
+  "dataManagementApiUrl": "http://localhost:9193/api/v1/data",
+  "storageAccount": "company3assets",
+  "storageExplorerLinkTemplate": "storageexplorer://v=1",
+  "theme": "theme-3"
+}

--- a/system-tests/resources/webdid/company1/did.json
+++ b/system-tests/resources/webdid/company1/did.json
@@ -6,11 +6,18 @@
 			"@base": "did:web:did-server:company1"
 		}
 	],
-	"service": [{
-		"id": "#identity-hub-url",
-		"type": "IdentityHub",
-		"serviceEndpoint": "http://company1:8181/api/identity-hub"
-	}],
+	"service": [
+		{
+			"id": "#identity-hub-url",
+			"type": "IdentityHub",
+			"serviceEndpoint": "http://company1:8181/api/identity-hub"
+		},
+		{
+			"id": "#ids-url",
+			"type": "IDSMessaging",
+			"serviceEndpoint": "http://company1:8282"
+		}
+	],
 	"verificationMethod": [{
 		"id": "#my-key-1",
 		"controller": "",

--- a/system-tests/resources/webdid/company2/did.json
+++ b/system-tests/resources/webdid/company2/did.json
@@ -6,11 +6,18 @@
 			"@base": "did:web:did-server:company2"
 		}
 	],
-	"service": [{
-		"id": "#identity-hub-url",
-		"type": "IdentityHub",
-		"serviceEndpoint": "http://company2:8181/api/identity-hub"
-	}],
+	"service": [
+		{
+			"id": "#identity-hub-url",
+			"type": "IdentityHub",
+			"serviceEndpoint": "http://company2:8181/api/identity-hub"
+		},
+		{
+			"id": "#ids-url",
+			"type": "IDSMessaging",
+			"serviceEndpoint": "http://company2:8282"
+		}
+	],
 	"verificationMethod": [{
 		"id": "#my-key-1",
 		"controller": "",

--- a/system-tests/resources/webdid/company3/did.json
+++ b/system-tests/resources/webdid/company3/did.json
@@ -6,11 +6,18 @@
 			"@base": "did:web:did-server:company3"
 		}
 	],
-	"service": [{
-		"id": "#identity-hub-url",
-		"type": "IdentityHub",
-		"serviceEndpoint": "http://company3:8181/api/identity-hub"
-	}],
+	"service": [
+		{
+			"id": "#identity-hub-url",
+			"type": "IdentityHub",
+			"serviceEndpoint": "http://company3:8181/api/identity-hub"
+		},
+		{
+			"id": "#ids-url",
+			"type": "IDSMessaging",
+			"serviceEndpoint": "http://company3:8282"
+		}
+	],
 	"verificationMethod": [{
 		"id": "#my-key-1",
 		"controller": "",


### PR DESCRIPTION
## What this PR changes/adds

Add Application insights connection string to Registration Service deployment set up.

## Why it does that

To enable collecting traces, logs and metrics in Azure Insights for Registration Service instance.

## Further notes

Fix after upgrading Registration Service version: use ParticipantDto in RegistrationServiceNodeDirectory class.

## Linked Issue(s)

Linked to #247 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
