### PR TITLE
Remove useless local_file Terraform resource

### DIFF
--- a/deployment/terraform/participant/main.tf
+++ b/deployment/terraform/participant/main.tf
@@ -292,14 +292,3 @@ resource "azurerm_storage_blob" "did" {
   ] })
   content_type = "application/json"
 }
-
-resource "local_file" "registry_entry" {
-  content = jsonencode({
-    # `name` must be identical to EDC connector EDC_CONNECTOR_NAME setting for catalog asset filtering to
-    # exclude assets from own connector.
-    name               = local.connector_name,
-    url                = "http://${azurerm_container_group.edc.fqdn}:${local.edc_ids_port}",
-    supportedProtocols = ["ids-multipart"]
-  })
-  filename = "${path.module}/build/${var.participant_name}.json"
-}


### PR DESCRIPTION
## What this PR changes/adds

Remove useless `local_file` Terraform resource

## Why it does that

## Further notes

This was used previously when the registry was a file share, and is not needed now the registry is a REST service.

## Linked Issue(s)

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly?
